### PR TITLE
Implemented Teams CRUD

### DIFF
--- a/.github/workflows/ci-cd-workflow.yaml
+++ b/.github/workflows/ci-cd-workflow.yaml
@@ -76,9 +76,12 @@ jobs:
             --no-build \
             --verbosity normal \
             --filter "TestCategory=UnitTest" \
-            --nologo
+            --nologo \
+            /p:CollectCoverage=true
 
       - uses: codecov/codecov-action@v2
+        with:
+          files: ./src/Tsa.Submissions.Coding.Tests/coverage.json
 
       - name: Publish Web API
         working-directory: ./src

--- a/.github/workflows/ci-cd-workflow.yaml
+++ b/.github/workflows/ci-cd-workflow.yaml
@@ -77,11 +77,12 @@ jobs:
             --verbosity normal \
             --filter "TestCategory=UnitTest" \
             --nologo \
-            /p:CollectCoverage=true
+            /p:CollectCoverage=true \
+            /p:CoverletOutputFormat=opencover
 
       - uses: codecov/codecov-action@v2
         with:
-          files: ./src/Tsa.Submissions.Coding.Tests/coverage.json
+          files: ./src/Tsa.Submissions.Coding.Tests/coverage.opencover.xml
 
       - name: Publish Web API
         working-directory: ./src

--- a/.github/workflows/ci-cd-workflow.yaml
+++ b/.github/workflows/ci-cd-workflow.yaml
@@ -77,7 +77,9 @@ jobs:
             --verbosity normal \
             --filter "TestCategory=UnitTest" \
             --nologo
-      
+
+      - uses: codecov/codecov-action@v2
+
       - name: Publish Web API
         working-directory: ./src
         run: |

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,0 +1,5 @@
+mode: Mainline
+branches: {}
+ignore:
+  sha: []
+merge-message-formats: {}

--- a/README.md
+++ b/README.md
@@ -79,17 +79,11 @@ For this reason, there is a Docker Compose project that is set as the default to
 *TODO: Write instructions for CLI*
 
 ### Making Your First Call
-Making your first API call can be a bit of challenge if you are unfamiliar with how to get a JWT from an identity provider.
-This API uses the [TSA Identity Server][tsa-identity-server] as the identity provider which is built on IdentityServer4.
-Further details on this solution can be found by navigating to the repo that houses the solution.
-
-First step is to ensure you have the [TSA Identity Server][tsa-identity-server] container running, either via `docker run` or `docker-compose up`. If you are running from Visual Studio 2019 or later, lauching the `docker-compose` project will handle this.
-
-Next, you must retrieve a JWT from the identity provider.
-The easiest way to achieve this is by using Postman.
-Details of how this can be achieved can be found in their documentation [Authorizing requests][postman-auth].
-
-Since the values used by Postman to retrieve your JWT are dependant upon the configuration of the [TSA Identity Server][tsa-identity-server], refer to its documenation for the specific values to use. 
+This project has been setup with Swagger and Swagger UI to allow.
+The Swagger UI has been configured to make use of OAuth2 authentication against the TSA IdentityServer container.
+Simply launch the Docker Compose and navigate to the Swagger API endpoint (as defined in the `src\Tsa.Submissions.Coding.WebApi\Startup.cs` file).
+Simply click the "Authorize" button and select all scopes before logging in.
+When prompted, enter credientials that are provided by the TSA IdentityServer or by adding your own.
 
 # Contributing
 We welcome anyone that would like to volunteer their time and contribute to this project.

--- a/src/Tsa.Submissions.Coding.Tests/Data/InvalidTeamTestData.cs
+++ b/src/Tsa.Submissions.Coding.Tests/Data/InvalidTeamTestData.cs
@@ -1,0 +1,98 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using Tsa.Submissions.Coding.WebApi.Models;
+
+namespace Tsa.Submissions.Coding.Tests.Data;
+
+internal class InvalidTeamTestData : IEnumerable<object[]>
+{
+    public IEnumerator<object[]> GetEnumerator()
+    {
+        // Bad School Number
+        yield return new object[] { new Team { SchoolNumber = "dog", TeamNumber = "901" } };
+
+        // Bad School Number and Team Number
+        yield return new object[] { new Team { SchoolNumber = "dog", TeamNumber = "101" } };
+        yield return new object[] { new Team { SchoolNumber = "dog", TeamNumber = "bird" } };
+
+        // Bad Team Number
+        yield return new object[] { new Team { SchoolNumber = "9999", TeamNumber = "101" } };
+        yield return new object[] { new Team { SchoolNumber = "9999", TeamNumber = "bird" } };
+
+        // Bad School Number and Team Number with Bad Participants
+        yield return new object[]
+        {
+            new Team
+            {
+                SchoolNumber = "dog",
+                TeamNumber = "bird",
+                Participants = new List<Participant>
+                {
+                    new() {ParticipantNumber = "dog", SchoolNumber = "dog"}
+                }
+            }
+        };
+
+        // Good School Number and Team Number with Bad Participants
+        yield return new object[]
+        {
+            new Team
+            {
+                SchoolNumber = "9999",
+                TeamNumber = "901",
+                Participants = new List<Participant>
+                {
+                    new() {ParticipantNumber = "dog", SchoolNumber = "dog"}
+                }
+            }
+        };
+
+        yield return new object[]
+        {
+            new Team
+            {
+                SchoolNumber = "9999",
+                TeamNumber = "901",
+                Participants = new List<Participant>
+                {
+                    new() {ParticipantNumber = "101", SchoolNumber = "9999"},
+                    new() {ParticipantNumber = "102", SchoolNumber = "9999"},
+                    new() {ParticipantNumber = "103", SchoolNumber = "9999"}
+                }
+            }
+        };
+
+        yield return new object[]
+        {
+            new Team
+            {
+                SchoolNumber = "9999",
+                TeamNumber = "901",
+                Participants = new List<Participant>
+                {
+                    new() {ParticipantNumber = "901", SchoolNumber = "9999"},
+                    new() {ParticipantNumber = "102", SchoolNumber = "9999"}
+                }
+            }
+        };
+
+        yield return new object[]
+        {
+            new Team
+            {
+                SchoolNumber = "9999",
+                TeamNumber = "901",
+                Participants = new List<Participant>
+                {
+                    new() {ParticipantNumber = "102", SchoolNumber = "9999"},
+                    new() {ParticipantNumber = "102", SchoolNumber = "9999"}
+                }
+            }
+        };
+    }
+
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return GetEnumerator();
+    }
+}

--- a/src/Tsa.Submissions.Coding.Tests/Tsa.Submissions.Coding.Tests.csproj
+++ b/src/Tsa.Submissions.Coding.Tests/Tsa.Submissions.Coding.Tests.csproj
@@ -20,4 +20,8 @@
     </PackageReference>
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\Tsa.Submissions.Coding.WebApi\Tsa.Submissions.Coding.WebApi.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/src/Tsa.Submissions.Coding.Tests/Tsa.Submissions.Coding.Tests.csproj
+++ b/src/Tsa.Submissions.Coding.Tests/Tsa.Submissions.Coding.Tests.csproj
@@ -13,6 +13,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Tsa.Submissions.Coding.Tests/Tsa.Submissions.Coding.Tests.csproj
+++ b/src/Tsa.Submissions.Coding.Tests/Tsa.Submissions.Coding.Tests.csproj
@@ -8,13 +8,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/Tsa.Submissions.Coding.Tests/WebApi/Controllers/TeamsControllerTests.cs
+++ b/src/Tsa.Submissions.Coding.Tests/WebApi/Controllers/TeamsControllerTests.cs
@@ -1,0 +1,317 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Tsa.Submissions.Coding.WebApi.Controllers;
+using Tsa.Submissions.Coding.WebApi.Models;
+using Tsa.Submissions.Coding.WebApi.Services;
+using Xunit;
+
+namespace Tsa.Submissions.Coding.Tests.WebApi.Controllers;
+
+//TODO: Add for testing participants
+public class TeamsControllerTests
+{
+    [Fact]
+    [Trait("AppLayer", "API")]
+    [Trait("TestCategory", "UnitTest")]
+    public async void TeamsController_Delete_By_Id_Should_Return_No_Content()
+    {
+        // Arrange
+        const string expectedId = "1234567890";
+
+        var expectedTeam = new Team
+        {
+            Id = expectedId,
+            SchoolNumber = "9999",
+            TeamNumber = "901"
+        };
+
+        var mockedTeamsService = new Mock<ITeamsService>();
+
+        mockedTeamsService.Setup(m => m.GetAsync(It.Is<string>(s => s == expectedId)))
+            .Returns(Task.FromResult(expectedTeam));
+
+        var teamsController = new TeamsController(mockedTeamsService.Object);
+
+        // Act
+        var actionResult = await teamsController.Delete(expectedId);
+
+        // Assert
+        Assert.NotNull(actionResult);
+        Assert.IsType<NoContentResult>(actionResult);
+
+        mockedTeamsService.Verify(m => m.GetAsync(It.IsAny<string>()), Times.Once);
+        mockedTeamsService.Verify(m => m.RemoveAsync(It.IsAny<string>()), Times.Once);
+    }
+
+    [Fact]
+    [Trait("AppLayer", "API")]
+    [Trait("TestCategory", "UnitTest")]
+    public async void TeamsController_Delete_By_Id_Should_Return_Not_Found()
+    {
+        // Arrange
+        Team? nullTeam = null;
+
+        var mockedTeamsService = new Mock<ITeamsService>();
+
+        mockedTeamsService.Setup(m => m.GetAsync(It.IsAny<string>()))
+            .Returns(Task.FromResult(nullTeam));
+
+        var teamsController = new TeamsController(mockedTeamsService.Object);
+
+        // Act
+        var actionResult = await teamsController.Delete("1234567890");
+
+        // Assert
+        Assert.NotNull(actionResult);
+        Assert.IsType<NotFoundResult>(actionResult);
+
+        mockedTeamsService.Verify(m => m.GetAsync(It.IsAny<string>()), Times.Once);
+        mockedTeamsService.Verify(m => m.RemoveAsync(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    [Trait("AppLayer", "API")]
+    [Trait("TestCategory", "UnitTest")]
+    public async void TeamsController_Get_By_Id_Should_Return_A_Team()
+    {
+        // Arrange
+        const string expectedId = "1234567890";
+
+        var expectedTeam = new Team
+        {
+            Id = expectedId,
+            SchoolNumber = "9999",
+            TeamNumber = "901"
+        };
+
+        var mockedTeamsService = new Mock<ITeamsService>();
+
+        mockedTeamsService.Setup(m => m.GetAsync(It.Is<string>(s => s == expectedId)))
+            .Returns(Task.FromResult(expectedTeam));
+
+        var teamsController = new TeamsController(mockedTeamsService.Object);
+
+        // Act
+        var actionResult = await teamsController.Get(expectedId);
+
+        // Assert
+        Assert.NotNull(actionResult);
+        Assert.NotNull(actionResult.Value);
+        Assert.Equal(expectedTeam.Id, actionResult.Value!.Id);
+        Assert.Equal(expectedTeam.SchoolNumber, actionResult.Value.SchoolNumber);
+        Assert.Equal(expectedTeam.TeamId, actionResult.Value.TeamId);
+        Assert.Equal(expectedTeam.TeamNumber, actionResult.Value.TeamNumber);
+
+        mockedTeamsService.Verify(m => m.GetAsync(It.IsAny<string>()), Times.Once);
+    }
+
+    [Fact]
+    [Trait("AppLayer", "API")]
+    [Trait("TestCategory", "UnitTest")]
+    public async void TeamsController_Get_By_Id_Should_Return_Not_Found()
+    {
+        // Arrange
+        Team? nullTeam = null;
+
+        var mockedTeamsService = new Mock<ITeamsService>();
+
+        mockedTeamsService.Setup(m => m.GetAsync(It.IsAny<string>()))
+            .Returns(Task.FromResult(nullTeam));
+
+        var teamsController = new TeamsController(mockedTeamsService.Object);
+
+        // Act
+        var actionResult = await teamsController.Get("1234567890");
+
+        // Assert
+        Assert.NotNull(actionResult);
+        Assert.NotNull(actionResult.Result);
+        Assert.IsType<NotFoundResult>(actionResult.Result);
+
+        mockedTeamsService.Verify(m => m.GetAsync(It.IsAny<string>()), Times.Once);
+    }
+
+    [Fact]
+    [Trait("AppLayer", "API")]
+    [Trait("TestCategory", "UnitTest")]
+    public async void TeamsController_Get_Should_Return_Empty_List()
+    {
+        // Arrange
+        var mockedTeamsService = new Mock<ITeamsService>();
+
+        mockedTeamsService.Setup(m => m.GetAsync())
+            .Returns(Task.FromResult(new List<Team>()));
+
+        var teamsController = new TeamsController(mockedTeamsService.Object);
+
+        // Act
+        var actualTeams = await teamsController.Get();
+
+        // Assert
+        Assert.Empty(actualTeams);
+
+        mockedTeamsService.Verify(m => m.GetAsync(), Times.Once);
+    }
+
+    [Fact]
+    [Trait("AppLayer", "API")]
+    [Trait("TestCategory", "UnitTest")]
+    public async void TeamsController_Get_Should_Return_None_Empty_List()
+    {
+        // Arrange
+        var expectedTeams = new List<Team>
+        {
+            new() { Id = "1", SchoolNumber = "9999", TeamNumber = "901" },
+            new() { Id = "2", SchoolNumber = "9999", TeamNumber = "902" },
+            new() { Id = "3", SchoolNumber = "9999", TeamNumber = "903" }
+        };
+
+        var mockedTeamsService = new Mock<ITeamsService>();
+
+        mockedTeamsService.Setup(m => m.GetAsync())
+            .Returns(Task.FromResult(expectedTeams));
+
+        var teamsController = new TeamsController(mockedTeamsService.Object);
+
+        // Act
+        var actualTeams = (await teamsController.Get()).ToList();
+
+        // Assert
+        Assert.NotEmpty(actualTeams);
+        Assert.True(expectedTeams.Count == actualTeams.Count);
+
+        foreach (var actualTeam in actualTeams)
+        {
+            var expectedTeam = expectedTeams.SingleOrDefault(t => t.Id == actualTeam.Id);
+
+            Assert.NotNull(expectedTeam);
+
+            Assert.Equal(expectedTeam!.SchoolNumber, actualTeam.SchoolNumber);
+            Assert.Equal(expectedTeam.TeamId, actualTeam.TeamId);
+            Assert.Equal(expectedTeam.TeamNumber, actualTeam.TeamNumber);
+        }
+
+        mockedTeamsService.Verify(m => m.GetAsync(), Times.Once);
+    }
+
+    [Fact]
+    [Trait("AppLayer", "API")]
+    [Trait("TestCategory", "UnitTest")]
+    public async void TeamsController_Post_Should_Return_A_Team()
+    {
+        // Arrange
+        const string expectedId = "1234567890";
+
+        var expectedTeam = new Team
+        {
+            Id = expectedId,
+            SchoolNumber = "9999",
+            TeamNumber = "901"
+        };
+
+        var newTeam = new Team
+        {
+            SchoolNumber = expectedTeam.SchoolNumber,
+            TeamNumber = expectedTeam.TeamNumber
+        };
+
+        Func<Team, bool> checkNewTeamFunc = submittedTeam => submittedTeam.SchoolNumber == newTeam.SchoolNumber && submittedTeam.TeamNumber == newTeam.TeamNumber;
+
+        var mockedTeamsService = new Mock<ITeamsService>();
+
+        mockedTeamsService.Setup(m => m.CreateAsync(It.IsAny<Team>()))
+            .Callback((Team team) => team.Id = expectedId);
+
+        var teamsController = new TeamsController(mockedTeamsService.Object);
+
+        // Act
+        var actionResult = await teamsController.Post(newTeam);
+
+        Assert.NotNull(actionResult);
+        Assert.NotNull(actionResult.Result);
+        Assert.IsType<CreatedAtActionResult>(actionResult.Result);
+
+        var actualTeam = ((CreatedAtActionResult)actionResult.Result!).Value as Team;
+
+        Assert.NotNull(actualTeam);
+        Assert.Equal(expectedTeam.Id, actualTeam!.Id);
+        Assert.Equal(expectedTeam.SchoolNumber, actualTeam.SchoolNumber);
+        Assert.Equal(expectedTeam.TeamId, actualTeam.TeamId);
+        Assert.Equal(expectedTeam.TeamNumber, actualTeam.TeamNumber);
+
+        mockedTeamsService.Verify(m => m.CreateAsync(It.Is<Team>(data => checkNewTeamFunc(data))));
+    }
+
+    [Fact]
+    [Trait("AppLayer", "API")]
+    [Trait("TestCategory", "UnitTest")]
+    public async void TeamsController_Put_Should_Return_No_Content()
+    {
+        // Arrange
+        const string expectedId = "1234567890";
+
+        var expectedTeam = new Team
+        {
+            Id = expectedId,
+            SchoolNumber = "9999",
+            TeamNumber = "901"
+        };
+
+        var mockedTeamsService = new Mock<ITeamsService>();
+
+        Func<Team, bool> checkNewTeamFunc = submittedTeam => submittedTeam.SchoolNumber == expectedTeam.SchoolNumber && submittedTeam.TeamNumber == expectedTeam.TeamNumber;
+
+        mockedTeamsService.Setup(m => m.GetAsync(It.Is<string>(s => s == expectedId)))
+            .Returns(Task.FromResult(expectedTeam));
+
+        var teamsController = new TeamsController(mockedTeamsService.Object);
+
+        // Act
+        var actionResult = await teamsController.Put(expectedId, expectedTeam);
+
+        // Assert
+        Assert.NotNull(actionResult);
+        Assert.IsType<NoContentResult>(actionResult);
+
+        mockedTeamsService.Verify(m => m.GetAsync(It.IsAny<string>()), Times.Once);
+        mockedTeamsService.Verify(m => m.UpdateAsync(It.Is<string>(s => s == expectedId), It.Is<Team>(data => checkNewTeamFunc(data))));
+    }
+
+    [Fact]
+    [Trait("AppLayer", "API")]
+    [Trait("TestCategory", "UnitTest")]
+    public async void TeamsController_Put_Should_Return_Not_Found()
+    {
+        // Arrange
+        Team? nullTeam = null;
+
+        const string expectedId = "1234567890";
+
+        var expectedTeam = new Team
+        {
+            Id = expectedId,
+            SchoolNumber = "9999",
+            TeamNumber = "901"
+        };
+
+        var mockedTeamsService = new Mock<ITeamsService>();
+
+        mockedTeamsService.Setup(m => m.GetAsync(It.IsAny<string>()))
+            .Returns(Task.FromResult(nullTeam));
+
+        var teamsController = new TeamsController(mockedTeamsService.Object);
+
+        // Act
+        var actionResult = await teamsController.Put(expectedId, expectedTeam);
+
+        // Assert
+        Assert.NotNull(actionResult);
+        Assert.IsType<NotFoundResult>(actionResult);
+
+        mockedTeamsService.Verify(m => m.GetAsync(It.IsAny<string>()), Times.Once);
+    }
+}

--- a/src/Tsa.Submissions.Coding.WebApi/Authorization/SubmissionRoles.cs
+++ b/src/Tsa.Submissions.Coding.WebApi/Authorization/SubmissionRoles.cs
@@ -1,0 +1,10 @@
+﻿namespace Tsa.Submissions.Coding.WebApi.Authorization;
+
+public static class SubmissionRoles
+{
+    public const string Judge = "judge";
+
+    public const string Participant = "participant";
+
+    public const string All = $"{Judge},{Participant}";
+}

--- a/src/Tsa.Submissions.Coding.WebApi/Configuration/SubmissionsDatabase.cs
+++ b/src/Tsa.Submissions.Coding.WebApi/Configuration/SubmissionsDatabase.cs
@@ -1,0 +1,27 @@
+﻿namespace Tsa.Submissions.Coding.WebApi.Configuration;
+
+public class SubmissionsDatabase
+{
+    public string ConnectionString
+    {
+        get
+        {
+            if (string.IsNullOrEmpty(User) || string.IsNullOrEmpty(Password))
+                return $@"mongodb://{Host}:{Port}";
+
+            return $@"mongodb://{User}:{Password}@{Host}:{Port}";
+        }
+    }
+
+    public string DatabaseName { get; set; }
+
+    public string Host { get; set; }
+
+    public string Password { get; set; }
+
+    public int Port { get; set; }
+
+    public string User { get; set; }
+
+    public string TeamsCollectionName { get; set; }
+}

--- a/src/Tsa.Submissions.Coding.WebApi/Controllers/TeamsController.cs
+++ b/src/Tsa.Submissions.Coding.WebApi/Controllers/TeamsController.cs
@@ -1,7 +1,10 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Tsa.Submissions.Coding.WebApi.Authorization;
 using Tsa.Submissions.Coding.WebApi.Models;
 using Tsa.Submissions.Coding.WebApi.Services;
 
@@ -12,6 +15,8 @@ namespace Tsa.Submissions.Coding.WebApi.Controllers;
 public class TeamsController : ControllerBase
 {
     private readonly ITeamsService _teamsService;
+    private const string ValidParticipantIdRegEx = @"[\d]{4}-[0-8][\d]{2}";
+    private const string ValidTeamIdRegEx = @"[\d]{4}-9[\d]{2}";
 
     public TeamsController(ITeamsService teamsService)
     {
@@ -30,26 +35,51 @@ public class TeamsController : ControllerBase
         return NoContent();
     }
 
+    [Authorize(Roles = SubmissionRoles.Judge)]
     [HttpGet]
     public async Task<IEnumerable<Team>> Get()
     {
         return await _teamsService.GetAsync();
     }
 
+    [Authorize(Roles = SubmissionRoles.All)]
     [HttpGet("{id:length(24)}")]
     public async Task<ActionResult<Team>> Get(string id)
     {
         var team = await _teamsService.GetAsync(id);
+
+        if (User.IsInRole(SubmissionRoles.Participant) &&
+            (team == null || team.Participants.All(p => p.ParticipantId != User!.Identity!.Name)))
+            return Unauthorized();
 
         return team == null
             ? NotFound()
             : team;
     }
 
-    [Authorize(Roles = "judge")]
+    private static bool IsTeamValid(Team team)
+    {
+        if (!Regex.IsMatch(team.TeamId, ValidTeamIdRegEx)) return false;
+
+        if (!team.Participants.Any()) return true;
+
+        if (team.Participants.Count > 2) return false;
+
+        if (team.Participants.Any(p => !Regex.IsMatch(p.ParticipantId, ValidParticipantIdRegEx))) return false;
+
+        if (team.Participants.Any(p => p.SchoolNumber != team.SchoolNumber)) return false;
+
+        if (team.Participants.Select(p => p.ParticipantId).Distinct().Count() != team.Participants.Count) return false;
+
+        return true;
+    }
+
+    [Authorize(Roles = SubmissionRoles.Judge)]
     [HttpPost]
     public async Task<ActionResult<Team>> Post(Team newTeam)
     {
+        if (!IsTeamValid(newTeam)) return BadRequest();
+
         await _teamsService.CreateAsync(newTeam);
 
         return CreatedAtAction(nameof(Get), new { id = newTeam.Id }, newTeam);

--- a/src/Tsa.Submissions.Coding.WebApi/Controllers/TeamsController.cs
+++ b/src/Tsa.Submissions.Coding.WebApi/Controllers/TeamsController.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Tsa.Submissions.Coding.WebApi.Models;
 using Tsa.Submissions.Coding.WebApi.Services;
@@ -45,6 +46,7 @@ public class TeamsController : ControllerBase
             : team;
     }
 
+    [Authorize(Roles = "judge")]
     [HttpPost]
     public async Task<ActionResult<Team>> Post(Team newTeam)
     {

--- a/src/Tsa.Submissions.Coding.WebApi/Controllers/TeamsController.cs
+++ b/src/Tsa.Submissions.Coding.WebApi/Controllers/TeamsController.cs
@@ -23,6 +23,7 @@ public class TeamsController : ControllerBase
         _teamsService = teamsService;
     }
 
+    [Authorize(Roles = SubmissionRoles.Judge)]
     [HttpDelete("{id:length(24)}")]
     public async Task<IActionResult> Delete(string id)
     {
@@ -85,12 +86,15 @@ public class TeamsController : ControllerBase
         return CreatedAtAction(nameof(Get), new { id = newTeam.Id }, newTeam);
     }
 
+    [Authorize(Roles = SubmissionRoles.Judge)]
     [HttpPut("{id:length(24)}")]
     public async Task<IActionResult> Put(string id, Team updatedTeam)
     {
         var team = await _teamsService.GetAsync(id);
 
         if (team == null) return NotFound();
+
+        if (!IsTeamValid(updatedTeam)) return BadRequest();
 
         updatedTeam.Id = team.Id;
 

--- a/src/Tsa.Submissions.Coding.WebApi/Controllers/TeamsController.cs
+++ b/src/Tsa.Submissions.Coding.WebApi/Controllers/TeamsController.cs
@@ -1,0 +1,69 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Tsa.Submissions.Coding.WebApi.Models;
+using Tsa.Submissions.Coding.WebApi.Services;
+
+namespace Tsa.Submissions.Coding.WebApi.Controllers;
+
+[Route("api/[controller]")]
+[ApiController]
+public class TeamsController : ControllerBase
+{
+    private readonly ITeamsService _teamsService;
+
+    public TeamsController(ITeamsService teamsService)
+    {
+        _teamsService = teamsService;
+    }
+
+    [HttpDelete("{id:length(24)}")]
+    public async Task<IActionResult> Delete(string id)
+    {
+        var team = await _teamsService.GetAsync(id);
+
+        if (team == null) return NotFound();
+
+        await _teamsService.RemoveAsync(id);
+
+        return NoContent();
+    }
+
+    [HttpGet]
+    public async Task<IEnumerable<Team>> Get()
+    {
+        return await _teamsService.GetAsync();
+    }
+
+    [HttpGet("{id:length(24)}")]
+    public async Task<ActionResult<Team>> Get(string id)
+    {
+        var team = await _teamsService.GetAsync(id);
+
+        return team == null
+            ? NotFound()
+            : team;
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<Team>> Post(Team newTeam)
+    {
+        await _teamsService.CreateAsync(newTeam);
+
+        return CreatedAtAction(nameof(Get), new { id = newTeam.Id }, newTeam);
+    }
+
+    [HttpPut("{id:length(24)}")]
+    public async Task<IActionResult> Put(string id, Team updatedTeam)
+    {
+        var team = await _teamsService.GetAsync(id);
+
+        if (team == null) return NotFound();
+
+        updatedTeam.Id = team.Id;
+
+        await _teamsService.UpdateAsync(id, updatedTeam);
+
+        return NoContent();
+    }
+}

--- a/src/Tsa.Submissions.Coding.WebApi/Middleware/AuthorizeCheckOperationFilter.cs
+++ b/src/Tsa.Submissions.Coding.WebApi/Middleware/AuthorizeCheckOperationFilter.cs
@@ -1,0 +1,31 @@
+﻿using System.Collections.Generic;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace Tsa.Submissions.Coding.WebApi.Middleware;
+
+public class AuthorizeCheckOperationFilter : IOperationFilter
+{
+    public void Apply(OpenApiOperation operation, OperationFilterContext context)
+    {
+        operation.Responses.Add("401", new OpenApiResponse { Description = "Unauthorized" });
+        operation.Responses.Add("403", new OpenApiResponse { Description = "Forbidden" });
+
+        operation.Security = new List<OpenApiSecurityRequirement>
+        {
+            new()
+            {
+                [
+                    new OpenApiSecurityScheme
+                    {
+                        Reference = new OpenApiReference
+                        {
+                            Type = ReferenceType.SecurityScheme,
+                            Id = "oauth2"
+                        }
+                    }
+                ] = new[] { "tsa.coding.submissions.read", "tsa.coding.submissions.create" }
+            }
+        };
+    }
+}

--- a/src/Tsa.Submissions.Coding.WebApi/Models/Participant.cs
+++ b/src/Tsa.Submissions.Coding.WebApi/Models/Participant.cs
@@ -1,0 +1,17 @@
+﻿using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace Tsa.Submissions.Coding.WebApi.Models;
+
+public class Participant
+{
+    [BsonId]
+    [BsonRepresentation(BsonType.ObjectId)]
+    public string Id { get; set; }
+
+    public string ParticipantNumber { get; set; }
+
+    public string SchoolNumber { get; set; }
+
+    public string ParticipantId => $"{SchoolNumber}-{ParticipantNumber}";
+}

--- a/src/Tsa.Submissions.Coding.WebApi/Models/Participant.cs
+++ b/src/Tsa.Submissions.Coding.WebApi/Models/Participant.cs
@@ -1,17 +1,10 @@
-﻿using MongoDB.Bson;
-using MongoDB.Bson.Serialization.Attributes;
-
-namespace Tsa.Submissions.Coding.WebApi.Models;
+﻿namespace Tsa.Submissions.Coding.WebApi.Models;
 
 public class Participant
 {
-    [BsonId]
-    [BsonRepresentation(BsonType.ObjectId)]
-    public string Id { get; set; }
+    public string ParticipantId => $"{SchoolNumber}-{ParticipantNumber}";
 
     public string ParticipantNumber { get; set; }
 
     public string SchoolNumber { get; set; }
-
-    public string ParticipantId => $"{SchoolNumber}-{ParticipantNumber}";
 }

--- a/src/Tsa.Submissions.Coding.WebApi/Models/Team.cs
+++ b/src/Tsa.Submissions.Coding.WebApi/Models/Team.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
+using Swashbuckle.AspNetCore.Annotations;
 
 namespace Tsa.Submissions.Coding.WebApi.Models;
 
@@ -8,6 +9,7 @@ public class Team
 {
     [BsonId]
     [BsonRepresentation(BsonType.ObjectId)]
+    [SwaggerSchema(ReadOnly = true)]
     public string Id { get; set; }
 
     public string SchoolNumber { get; set; }

--- a/src/Tsa.Submissions.Coding.WebApi/Models/Team.cs
+++ b/src/Tsa.Submissions.Coding.WebApi/Models/Team.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Diagnostics;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
 using Swashbuckle.AspNetCore.Annotations;
@@ -24,4 +25,6 @@ public class Team
     {
         Participants = new List<Participant>();
     }
+
+    public override string ToString() => TeamId;
 }

--- a/src/Tsa.Submissions.Coding.WebApi/Models/Team.cs
+++ b/src/Tsa.Submissions.Coding.WebApi/Models/Team.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace Tsa.Submissions.Coding.WebApi.Models;
+
+public class Team
+{
+    [BsonId]
+    [BsonRepresentation(BsonType.ObjectId)]
+    public string Id { get; set; }
+
+    public string SchoolNumber { get; set; }
+
+    public string TeamNumber { get; set; }
+
+    public string TeamId => $"{SchoolNumber}-{TeamNumber}";
+
+    public IList<Participant> Participants { get; set; }
+
+    public Team()
+    {
+        Participants = new List<Participant>();
+    }
+}

--- a/src/Tsa.Submissions.Coding.WebApi/Services/ITeamsService.cs
+++ b/src/Tsa.Submissions.Coding.WebApi/Services/ITeamsService.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Tsa.Submissions.Coding.WebApi.Models;
+
+namespace Tsa.Submissions.Coding.WebApi.Services;
+
+public interface ITeamsService
+{
+    Task CreateAsync(Team newTeam);
+
+    Task<List<Team>> GetAsync();
+
+    Task<Team> GetAsync(string id);
+
+    Task RemoveAsync(string id);
+
+    Task UpdateAsync(string id, Team updatedTeam);
+}

--- a/src/Tsa.Submissions.Coding.WebApi/Services/TeamsService.cs
+++ b/src/Tsa.Submissions.Coding.WebApi/Services/TeamsService.cs
@@ -1,0 +1,48 @@
+﻿#nullable enable
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using MongoDB.Driver;
+using Tsa.Submissions.Coding.WebApi.Configuration;
+using Tsa.Submissions.Coding.WebApi.Models;
+
+namespace Tsa.Submissions.Coding.WebApi.Services;
+
+public class TeamsService : ITeamsService
+{
+    private readonly IMongoCollection<Team> _teamsCollection;
+
+    public TeamsService(IOptions<SubmissionsDatabase> submissionsDatabaseConfiguration)
+    {
+        var mongoClient = new MongoClient(submissionsDatabaseConfiguration.Value.ConnectionString);
+
+        var mongoDatabase = mongoClient.GetDatabase(submissionsDatabaseConfiguration.Value.DatabaseName);
+
+        _teamsCollection = mongoDatabase.GetCollection<Team>(submissionsDatabaseConfiguration.Value.TeamsCollectionName);
+    }
+
+    public async Task CreateAsync(Team newTeam)
+    {
+        await _teamsCollection.InsertOneAsync(newTeam);
+    }
+
+    public async Task<List<Team>> GetAsync()
+    {
+        return await _teamsCollection.Find(_ => true).ToListAsync();
+    }
+
+    public async Task<Team?> GetAsync(string id)
+    {
+        return await _teamsCollection.Find(x => x.Id == id).FirstOrDefaultAsync();
+    }
+
+    public async Task RemoveAsync(string id)
+    {
+        await _teamsCollection.DeleteOneAsync(x => x.Id == id);
+    }
+
+    public async Task UpdateAsync(string id, Team updatedTeam)
+    {
+        await _teamsCollection.ReplaceOneAsync(x => x.Id == id, updatedTeam);
+    }
+}

--- a/src/Tsa.Submissions.Coding.WebApi/Startup.cs
+++ b/src/Tsa.Submissions.Coding.WebApi/Startup.cs
@@ -9,6 +9,8 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi.Models;
+using Tsa.Submissions.Coding.WebApi.Configuration;
+using Tsa.Submissions.Coding.WebApi.Services;
 
 namespace Tsa.Submissions.Coding.WebApi;
 
@@ -66,6 +68,10 @@ public class Startup
 
     public void ConfigureServices(IServiceCollection services)
     {
+        services.Configure<SubmissionsDatabase>(Configuration.GetSection("SubmissionsDatabase"));
+
+        services.AddSingleton<ITeamsService, TeamsService>();
+
         var requireAuthenticatedUserPolicy = new AuthorizationPolicyBuilder()
             .RequireAuthenticatedUser()
             .Build();

--- a/src/Tsa.Submissions.Coding.WebApi/Startup.cs
+++ b/src/Tsa.Submissions.Coding.WebApi/Startup.cs
@@ -109,6 +109,8 @@ public class Startup
         services.AddSwaggerGen(options =>
         {
             options.SwaggerDoc("v1", new OpenApiInfo { Title = "Tsa.Submissions.Coding.WebApi", Version = "v1" });
+            
+            options.EnableAnnotations();
 
             //TODO: Make a special "Swagger" API client for this
             options.AddSecurityDefinition("oauth2", new OpenApiSecurityScheme

--- a/src/Tsa.Submissions.Coding.WebApi/Startup.cs
+++ b/src/Tsa.Submissions.Coding.WebApi/Startup.cs
@@ -1,4 +1,7 @@
+using System;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
@@ -10,6 +13,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi.Models;
 using Tsa.Submissions.Coding.WebApi.Configuration;
+using Tsa.Submissions.Coding.WebApi.Middleware;
 using Tsa.Submissions.Coding.WebApi.Services;
 
 namespace Tsa.Submissions.Coding.WebApi;
@@ -27,14 +31,24 @@ public class Startup
     {
         if (env.IsDevelopment())
         {
+            app.UseCors(builder => builder.AllowAnyOrigin().AllowAnyHeader().AllowAnyMethod());
+
             app.UseDeveloperExceptionPage();
             app.UseSwagger();
-            app.UseSwaggerUI(c => c.SwaggerEndpoint("/swagger/v1/swagger.json", "Tsa.Submissions.Coding.WebApi v1"));
+            app.UseSwaggerUI(options =>
+            {
+                options.SwaggerEndpoint("/swagger/v1/swagger.json", "Tsa.Submissions.Coding.WebApi v1");
+
+                options.OAuthClientId("tsa.coding.submissions.web");
+                options.OAuthAppName("TSA Coding Submissions Web UI");
+                options.OAuthClientSecret(Configuration["Authentication:ClientSecret"]);
+                options.OAuthUsePkce();
+            });
 
             // In a development setting, all containers use the ASP.NET development certificate
             // Since this is a self signed certificate, the root CA must be trusted
             // The Docker Compose mounts a volume in the container for the root CA certificate
-            // This code block undates the trusted root CA so ASP.NET development certificates work
+            // This code block updates the trusted root CA so ASP.NET development certificates work
             var dockerContainer = Configuration["DOCKER_CONTAINER"] != null && Configuration["DOCKER_CONTAINER"] == "Y";
 
             if (dockerContainer)
@@ -70,6 +84,9 @@ public class Startup
     {
         services.Configure<SubmissionsDatabase>(Configuration.GetSection("SubmissionsDatabase"));
 
+        if (Configuration["DOCKER_CONTAINER"] != null && Configuration["DOCKER_CONTAINER"] == "Y")
+            services.AddCors();
+
         services.AddSingleton<ITeamsService, TeamsService>();
 
         var requireAuthenticatedUserPolicy = new AuthorizationPolicyBuilder()
@@ -85,8 +102,37 @@ public class Startup
                 options.TokenValidationParameters = new TokenValidationParameters { ValidateAudience = false };
             });
 
+        services.AddAuthorization(configuration => { configuration.AddPolicy("ShouldContainRole", options => options.RequireClaim(ClaimTypes.Role)); });
+
         services.AddControllers(configure => { configure.Filters.Add(new AuthorizeFilter(requireAuthenticatedUserPolicy)); });
 
-        services.AddSwaggerGen(c => { c.SwaggerDoc("v1", new OpenApiInfo { Title = "Tsa.Submissions.Coding.WebApi", Version = "v1" }); });
+        services.AddSwaggerGen(options =>
+        {
+            options.SwaggerDoc("v1", new OpenApiInfo { Title = "Tsa.Submissions.Coding.WebApi", Version = "v1" });
+
+            //TODO: Make a special "Swagger" API client for this
+            options.AddSecurityDefinition("oauth2", new OpenApiSecurityScheme
+            {
+                Type = SecuritySchemeType.OAuth2,
+                Flows = new OpenApiOAuthFlows
+                {
+                    AuthorizationCode = new OpenApiOAuthFlow
+                    {
+                        AuthorizationUrl = new Uri($"{Configuration["Authentication:Authority"]}/connect/authorize"),
+                        TokenUrl = new Uri($"{Configuration["Authentication:Authority"]}/connect/token"),
+                        Scopes = new Dictionary<string, string>
+                        {
+                            { "role", "Role in Submissions" },
+                            { "profile", "Your profile in Submissions" },
+                            { "openid", "" },
+                            { "tsa.coding.submissions.read", "Display/read coding submissions" },
+                            { "tsa.coding.submissions.create", "Create coding submissions" }
+                        }
+                    }
+                }
+            });
+
+            options.OperationFilter<AuthorizeCheckOperationFilter>();
+        });
     }
 }

--- a/src/Tsa.Submissions.Coding.WebApi/Startup.cs
+++ b/src/Tsa.Submissions.Coding.WebApi/Startup.cs
@@ -99,7 +99,12 @@ public class Startup
             {
                 options.Authority = Configuration["Authentication:Authority"];
 
-                options.TokenValidationParameters = new TokenValidationParameters { ValidateAudience = false };
+                options.TokenValidationParameters = new TokenValidationParameters
+                {
+                    //TODO: Find what static property this could pull from (likely in IdentityServer's libraries)
+                    NameClaimType = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier",
+                    ValidateAudience = false
+                };
             });
 
         services.AddAuthorization(configuration => { configuration.AddPolicy("ShouldContainRole", options => options.RequireClaim(ClaimTypes.Role)); });
@@ -124,9 +129,10 @@ public class Startup
                         TokenUrl = new Uri($"{Configuration["Authentication:Authority"]}/connect/token"),
                         Scopes = new Dictionary<string, string>
                         {
-                            { "role", "Role in Submissions" },
-                            { "profile", "Your profile in Submissions" },
+                            { "name", "" },
                             { "openid", "" },
+                            { "profile", "Your profile in Submissions" },
+                            { "role", "Role in Submissions" },
                             { "tsa.coding.submissions.read", "Display/read coding submissions" },
                             { "tsa.coding.submissions.create", "Create coding submissions" }
                         }

--- a/src/Tsa.Submissions.Coding.WebApi/Tsa.Submissions.Coding.WebApi.csproj
+++ b/src/Tsa.Submissions.Coding.WebApi/Tsa.Submissions.Coding.WebApi.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="MongoDB.Driver" Version="2.14.1" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.2.3" />
   </ItemGroup>
 
 </Project>

--- a/src/Tsa.Submissions.Coding.WebApi/Tsa.Submissions.Coding.WebApi.csproj
+++ b/src/Tsa.Submissions.Coding.WebApi/Tsa.Submissions.Coding.WebApi.csproj
@@ -11,7 +11,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.2" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.14.0" />
     <PackageReference Include="MongoDB.Driver" Version="2.14.1" />
-    <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.2.3" />
   </ItemGroup>

--- a/src/Tsa.Submissions.Coding.WebApi/Tsa.Submissions.Coding.WebApi.csproj
+++ b/src/Tsa.Submissions.Coding.WebApi/Tsa.Submissions.Coding.WebApi.csproj
@@ -10,6 +10,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.2" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.14.0" />
+    <PackageReference Include="MongoDB.Driver" Version="2.14.1" />
+    <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
   </ItemGroup>
 

--- a/src/Tsa.Submissions.Coding.WebApi/appsettings.Development.json
+++ b/src/Tsa.Submissions.Coding.WebApi/appsettings.Development.json
@@ -1,4 +1,12 @@
 {
+  "SubmissionsDatabase": {
+    "DatabaseName": "submissions",
+    "Host": "mongodb.tsa.local",
+    "Port": 27017,
+    "User": "root",
+    "Password": "rIMdEnfnHj395cFO",
+    "TeamsCollectionName": "teams" 
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/src/docker-compose.override.yml
+++ b/src/docker-compose.override.yml
@@ -19,6 +19,7 @@ services:
       ASPNETCORE_Kestrel__Certificates__Default__Password: "b05e4983-84e0-447d-97c0-3fdf5b91ddb4"
       ASPNETCORE_Kestrel__Certificates__Default__Path: "/https/identityServerCertificate.pfx"
       ConnectionStrings:TsaIdentityServer: "Server=db.tsa.local;Database=tsa-identity-server;User=sa;Password=rIMdEnfnHj395cFO;"
+      DOCKER_CONTAINER: "Y"
     expose:
       - "8001"
       - "44301"
@@ -60,6 +61,7 @@ services:
       DOCKER_CONTAINER: "Y"
       ConnectionStrings__SubmissionsContext: "Server=db.tsa.local;Database=tsa-coding-submissions;User=sa;Password=rIMdEnfnHj395cFO;"
       Authentication__Authority: "https://identity.tsa.local:44301"
+      Authentication__ClientSecret: "a673bbae-71e4-4962-a623-665689c4dd34"
     expose:
       - "44300"
     ports:

--- a/src/docker-compose.override.yml
+++ b/src/docker-compose.override.yml
@@ -33,6 +33,22 @@ services:
       - "15672:15672"
       - "5672:5672"
 
+  mongodb:
+    hostname: mongodb.tsa.local
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: root
+      MONGO_INITDB_ROOT_PASSWORD: rIMdEnfnHj395cFO
+    ports:
+      - 27017:27017
+
+  mongo-express:
+    environment:
+      ME_CONFIG_MONGODB_ADMINUSERNAME: root
+      ME_CONFIG_MONGODB_ADMINPASSWORD: rIMdEnfnHj395cFO
+      ME_CONFIG_MONGODB_SERVER: mongodb.tsa.local
+    ports:
+      - 8081:8081
+
   webapi:
     hostname: api.tsa.local
     environment:

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: mcr.microsoft.com/mssql/server:2019-latest
 
   identity:
-    image: webstorm.azurecr.io/tsa/coding/submissions/identity:0
+    image: ghcr.io/tj-cappelletti/tsa/coding/submissions/identity:0
     hostname: identity
     depends_on:
     - db

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -1,15 +1,6 @@
 version: '3.9'
 
 services:
-  webapi:
-    image: ${DOCKER_REGISTRY-}tsa-submissions-coding-webapi
-    build:
-      context: .
-      dockerfile: Tsa.Submissions.Coding.WebApi/Dockerfile
-    depends_on:
-    - identity
-    - rabbity-mq
-
   db:
     image: mcr.microsoft.com/mssql/server:2019-latest
 
@@ -21,3 +12,21 @@ services:
 
   rabbitmq:
     image: rabbitmq:3-management
+
+  mongodb:
+    image: mongo
+
+  mongo-express:
+    image: mongo-express
+    depends_on:
+    - mongodb
+
+  webapi:
+    image: ${DOCKER_REGISTRY-}tsa-submissions-coding-webapi
+    build:
+      context: .
+      dockerfile: Tsa.Submissions.Coding.WebApi/Dockerfile
+    depends_on:
+    - identity
+    - rabbity-mq
+    - mongodb


### PR DESCRIPTION
## Implemented Creation Endpoint
Implemented an API endpoint that creates a team from an `HTTP POST` JSON body. This body is validated to ensure only valid teams get created. Authorization role is set to ensure only judges can create a team. The team is stored in a MongoDB database. The generated ID for the document is then used as the ID in all subsequent API calls that interact with a single team.

## Implemented Read Endpoints
Implemented two API endpoints that retrieve teams. The first is a list option that is simply an `HTTP GET` operation with authorization roles scoped to just a judges. The second endpoint also uses an `HTTP GET` but accepts the ID of a team in the URL route to get a single team. Both the judge and participant roles have access to this endpoint, but in the case of a participant, only they can see their team's data. Logic was added to ensure this.

## Implemented Update Endpoint
Implemented an API endpoint that updates a team from an `HTTP PUT` JSON body. This body is validated and ensures that the team exists prior to attempting the update. Authorization role is set to ensure only judges can update a team.

## Implemented Delete Endpoint
Implemented an API endpoint that deletes a team using the `HTTP DELETE` method and the ID of the team in the URL route. The role authorization limits or judges to this action.

## Unit Testing
Unit testing patterns and practices were established for this repo as the result of these changes. The appropriate unit tests were added to cover valid and most edge case scenarios. There is room for improvement and likely a few edge cases that haven't been discovered yet, but this servers as a good starting point.

This closes issue #1 