### PR TITLE
Added Status Endpoint

### DIFF
--- a/src/Tsa.Submissions.Coding.Tests/WebApi/Controllers/StatusControllerTests.cs
+++ b/src/Tsa.Submissions.Coding.Tests/WebApi/Controllers/StatusControllerTests.cs
@@ -1,0 +1,73 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Tsa.Submissions.Coding.WebApi.Controllers;
+using Tsa.Submissions.Coding.WebApi.Models;
+using Tsa.Submissions.Coding.WebApi.Services;
+using Xunit;
+
+namespace Tsa.Submissions.Coding.Tests.WebApi.Controllers;
+
+/// <summary>
+///     Tests the status controller to ensure the right status is being returned
+/// </summary>
+public class StatusControllerTests
+{
+    [Fact]
+    [Trait("AppLayer", "API")]
+    [Trait("TestCategory", "UnitTest")]
+    //TODO: Improve naming convention as additional tests get written
+    public async void StatusController_Get_Should_Return_InternalServerError()
+    {
+        var mockedTeamsService = new Mock<ITeamsService>();
+
+        mockedTeamsService.Setup(m => m.Ping())
+            .ReturnsAsync(false);
+
+        var statusController = new StatusController(mockedTeamsService.Object);
+
+        // Act
+        var actionResult = await statusController.Get();
+
+        Assert.NotNull(actionResult);
+        Assert.IsType<ObjectResult>(actionResult);
+
+        var objectResult = (ObjectResult)actionResult;
+
+        Assert.Equal(500, objectResult.StatusCode);
+        Assert.NotNull(objectResult.Value);
+        Assert.IsType<Status>(objectResult.Value);
+
+        var status = (Status)objectResult.Value!;
+
+        Assert.False(status.IsHealthy);
+    }
+
+    [Fact]
+    [Trait("AppLayer", "API")]
+    [Trait("TestCategory", "UnitTest")]
+    //TODO: Improve naming convention as additional tests get written
+    public async void StatusController_Get_Should_Return_Ok()
+    {
+        var mockedTeamsService = new Mock<ITeamsService>();
+
+        mockedTeamsService.Setup(m => m.Ping())
+            .ReturnsAsync(true);
+
+        var statusController = new StatusController(mockedTeamsService.Object);
+
+        // Act
+        var actionResult = await statusController.Get();
+
+        Assert.NotNull(actionResult);
+        Assert.IsType<OkObjectResult>(actionResult);
+
+        var okObjectResult = (OkObjectResult)actionResult;
+
+        Assert.NotNull(okObjectResult.Value);
+        Assert.IsType<Status>(okObjectResult.Value);
+
+        var status = (Status)okObjectResult.Value!;
+
+        Assert.True(status.IsHealthy);
+    }
+}

--- a/src/Tsa.Submissions.Coding.WebApi/Controllers/StatusController.cs
+++ b/src/Tsa.Submissions.Coding.WebApi/Controllers/StatusController.cs
@@ -1,0 +1,34 @@
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Tsa.Submissions.Coding.WebApi.Models;
+using Tsa.Submissions.Coding.WebApi.Services;
+
+namespace Tsa.Submissions.Coding.WebApi.Controllers;
+
+[Route("api/[controller]")]
+[ApiController]
+public class StatusController : ControllerBase
+{
+    private readonly ITeamsService _teamsService;
+
+    public StatusController(ITeamsService teamsService)
+    {
+        _teamsService = teamsService;
+    }
+
+    [AllowAnonymous]
+    [HttpGet]
+    public async Task<IActionResult> Get()
+    {
+        var status = new Status
+        {
+            TeamsServiceIsAlive = await _teamsService.Ping()
+        };
+
+        return status.IsHealthy
+            ? Ok(status)
+            : StatusCode(StatusCodes.Status500InternalServerError, status);
+    }
+}

--- a/src/Tsa.Submissions.Coding.WebApi/Models/Status.cs
+++ b/src/Tsa.Submissions.Coding.WebApi/Models/Status.cs
@@ -1,0 +1,9 @@
+﻿namespace Tsa.Submissions.Coding.WebApi.Models
+{
+    public class Status
+    {
+        public bool TeamsServiceIsAlive { get; set; }
+
+        public bool IsHealthy => TeamsServiceIsAlive;
+    }
+}

--- a/src/Tsa.Submissions.Coding.WebApi/Services/ITeamsService.cs
+++ b/src/Tsa.Submissions.Coding.WebApi/Services/ITeamsService.cs
@@ -15,4 +15,6 @@ public interface ITeamsService
     Task RemoveAsync(string id);
 
     Task UpdateAsync(string id, Team updatedTeam);
+
+    Task<bool> Ping();
 }


### PR DESCRIPTION
This end point allows anonymous calls and returns the status of the API. The intention is each service that is to the API will get a status check which will help to determine if the API is healthy or not.