### PR TITLE
Implemented Test Sets Endpoint

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -73,7 +73,7 @@ jobs:
           dotnet build `
             ./src/Tsa.Submissions.Coding.sln `
             --configuration Release `
-            --no-incremental
+            --no-incremental `
             --nologo
 
           dotnet test ./src/Tsa.Submissions.Coding.UnitTests/Tsa.Submissions.Coding.UnitTests.csproj `

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -57,19 +57,34 @@ jobs:
           New-Item -Path .\.sonar\scanner -ItemType Directory
           dotnet tool update dotnet-sonarscanner --tool-path .\.sonar\scanner
 
-      - name: Install dotnet-coverage
-        shell: powershell
-        run: dotnet tool install --global dotnet-coverage
-
       - name: Build and analyze
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         shell: pwsh
         run: |
-          
-          .\.sonar\scanner/dotnet-sonarscanner begin /k:"tj-cappelletti_tsa-coding-submissions" /o:"tj-cappelletti" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io"
-          dotnet build ./src/Tsa.Submissions.Coding.sln --configuration Release --nologo
+          .\.sonar\scanner/dotnet-sonarscanner begin `
+            /k:"tj-cappelletti_tsa-coding-submissions" `
+            /o:"tj-cappelletti" `
+            /d:sonar.login="${{ secrets.SONAR_TOKEN }}" `
+            /d:sonar.host.url="https://sonarcloud.io" `
+            /d:sonar.cs.opencover.reportsPaths=.\src\Tsa.Submissions.Coding.UnitTests\coverage.opencover.xml
+
+          dotnet build `
+            ./src/Tsa.Submissions.Coding.sln `
+            --configuration Release `
+            --no-incremental
+            --nologo
+
+          dotnet test ./src/Tsa.Submissions.Coding.UnitTests/Tsa.Submissions.Coding.UnitTests.csproj `
+            --configuration Release `
+            --no-build `
+            --verbosity normal `
+            --filter "TestCategory=UnitTest" `
+            --nologo `
+            /p:CollectCoverage=true `
+            /p:CoverletOutputFormat=opencover
+
           dotnet-coverage collect 'dotnet test ./src/Tsa.Submissions.Coding.UnitTests/Tsa.Submissions.Coding.UnitTests.csproj' -f xml  -o 'coverage.xml'
           .\.sonar\scanner/dotnet-sonarscanner end /d:sonar.login="${{ secrets.SONAR_TOKEN }}"
       

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -85,6 +85,5 @@ jobs:
             /p:CollectCoverage=true `
             /p:CoverletOutputFormat=opencover
 
-          dotnet-coverage collect 'dotnet test ./src/Tsa.Submissions.Coding.UnitTests/Tsa.Submissions.Coding.UnitTests.csproj' -f xml  -o 'coverage.xml'
           .\.sonar\scanner/dotnet-sonarscanner end /d:sonar.login="${{ secrets.SONAR_TOKEN }}"
       

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -57,13 +57,17 @@ jobs:
           New-Item -Path .\.sonar\scanner -ItemType Directory
           dotnet tool update dotnet-sonarscanner --tool-path .\.sonar\scanner
 
+      - name: Install dotnet-coverage
+        shell: powershell
+        run: dotnet tool install --global dotnet-coverage
+
       - name: Build and analyze
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         shell: pwsh
         run: |
-          dotnet tool install --global dotnet-coverage
+          
           .\.sonar\scanner/dotnet-sonarscanner begin /k:"tj-cappelletti_tsa-coding-submissions" /o:"tj-cappelletti" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io"
           dotnet build ./src/Tsa.Submissions.Coding.sln --configuration Release --nologo
           dotnet-coverage collect 'dotnet test ./src/Tsa.Submissions.Coding.UnitTests/Tsa.Submissions.Coding.UnitTests.csproj' -f xml  -o 'coverage.xml'

--- a/src/Tsa.Submissions.Coding.UnitTests/Data/TestSetsTestData.cs
+++ b/src/Tsa.Submissions.Coding.UnitTests/Data/TestSetsTestData.cs
@@ -105,7 +105,7 @@ public class TestSetsTestData : IEnumerable<object[]>
                         ValueAsJson = "{ \"value\": 1 }"
                     }
                 },
-                IsPublic = true,
+                IsPublic = false,
                 Name = "Test Set #2",
                 Problem = new MongoDBRef(ProblemsService.MongoDbCollectionName, "000000000000000000000001")
             },

--- a/src/Tsa.Submissions.Coding.UnitTests/Data/TestSetsTestData.cs
+++ b/src/Tsa.Submissions.Coding.UnitTests/Data/TestSetsTestData.cs
@@ -29,13 +29,13 @@ public class TestSetsTestData : IEnumerable<object[]>
                     {
                         DataType = "string",
                         Index = 0,
-                        Value = "test value"
+                        ValueAsJson = "test value"
                     },
                     new()
                     {
                         DataType = "number",
                         Index = 1,
-                        Value = "1"
+                        ValueAsJson = "1"
                     }
                 },
                 IsPublic = true,
@@ -56,13 +56,13 @@ public class TestSetsTestData : IEnumerable<object[]>
                     {
                         DataType = "string",
                         Index = 0,
-                        Value = "test value"
+                        ValueAsJson = "test value"
                     },
                     new()
                     {
                         DataType = "number",
                         Index = 1,
-                        Value = "1"
+                        ValueAsJson = "1"
                     }
                 },
                 IsPublic = true,

--- a/src/Tsa.Submissions.Coding.UnitTests/Data/TestSetsTestData.cs
+++ b/src/Tsa.Submissions.Coding.UnitTests/Data/TestSetsTestData.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using MongoDB.Driver;
+using Tsa.Submissions.Coding.WebApi.Entities;
+using Tsa.Submissions.Coding.WebApi.Services;
+
+namespace Tsa.Submissions.Coding.UnitTests.Data;
+
+public class TestSetsTestData : IEnumerable<object[]>
+{
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return GetEnumerator();
+    }
+
+    public IEnumerator<object[]> GetEnumerator()
+    {
+        yield return new object[]
+        {
+            new TestSet
+            {
+                Id = "000000000000000000000001",
+                Inputs = new List<TestSetInput>
+                {
+                    new()
+                    {
+                        DataType = "string",
+                        Index = 0,
+                        Value = "test value"
+                    },
+                    new()
+                    {
+                        DataType = "number",
+                        Index = 1,
+                        Value = "1"
+                    }
+                },
+                IsPublic = true,
+                Name = "Test Set #1",
+                Problem = new MongoDBRef(ProblemsService.MongoDbCollectionName, "000000000000000000000001")
+            },
+            TestSetDataIssues.None
+        };
+
+        yield return new object[]
+        {
+            new TestSet
+            {
+                Id = "000000000000000000000002",
+                Inputs = new List<TestSetInput>
+                {
+                    new()
+                    {
+                        DataType = "string",
+                        Index = 0,
+                        Value = "test value"
+                    },
+                    new()
+                    {
+                        DataType = "number",
+                        Index = 1,
+                        Value = "1"
+                    }
+                },
+                IsPublic = true,
+                Name = "Test Set #2",
+                Problem = new MongoDBRef(ProblemsService.MongoDbCollectionName, "000000000000000000000001")
+            },
+            TestSetDataIssues.None
+        };
+    }
+}
+
+[Flags]
+public enum TestSetDataIssues
+{
+    None = 0
+}

--- a/src/Tsa.Submissions.Coding.UnitTests/Data/TestSetsTestData.cs
+++ b/src/Tsa.Submissions.Coding.UnitTests/Data/TestSetsTestData.cs
@@ -27,15 +27,55 @@ public class TestSetsTestData : IEnumerable<object[]>
                 {
                     new()
                     {
-                        DataType = "string",
+                        DataType = "character",
                         Index = 0,
-                        ValueAsJson = "{ \"value\": \"test value\" }"
+                        ValueAsJson = "{ \"value\": \"a\" }"
+                    },
+                    new()
+                    {
+                        DataType = "character",
+                        Index = 1,
+                        IsArray = true,
+                        ValueAsJson = "{ \"value\": [ \"a\", \"b\", \"c\" ] }"
+                    },
+                    new()
+                    {
+                        DataType = "decimal",
+                        Index = 2,
+                        ValueAsJson = "{ \"value\": 1.1 }"
+                    },
+                    new()
+                    {
+                        DataType = "decimal",
+                        Index = 3,
+                        IsArray = true,
+                        ValueAsJson = "{ \"value\": [ 1.1, 1.2, 1.3 ] }"
                     },
                     new()
                     {
                         DataType = "number",
-                        Index = 1,
+                        Index = 4,
                         ValueAsJson = "{ \"value\": 1 }"
+                    },
+                    new()
+                    {
+                        DataType = "number",
+                        Index = 5,
+                        IsArray = true,
+                        ValueAsJson = "{ \"value\": [ 1, 2, 3 ] }"
+                    },
+                    new()
+                    {
+                        DataType = "string",
+                        Index = 6,
+                        ValueAsJson = "{ \"value\": \"string a\" }"
+                    },
+                    new()
+                    {
+                        DataType = "string",
+                        Index = 7,
+                        IsArray = true,
+                        ValueAsJson = "{ \"value\": [ \"string a\", \"string b\", \"string c\" ] }"
                     }
                 },
                 IsPublic = true,
@@ -318,6 +358,33 @@ public class TestSetsTestData : IEnumerable<object[]>
             },
             TestSetDataIssues.ValueCannotBeDeserialized
         };
+
+        yield return new object[]
+        {
+            new TestSet
+            {
+                Id = "000000000000000000000012",
+                Inputs = new List<TestSetInput>
+                {
+                    new()
+                    {
+                        DataType = "string",
+                        Index = 0,
+                        ValueAsJson = "{ \"value\": \"test value\" }"
+                    },
+                    new()
+                    {
+                        DataType = "number",
+                        Index = 2,
+                        ValueAsJson = "{ \"value\": 1 }"
+                    }
+                },
+                IsPublic = true,
+                Name = "Test Set #2",
+                Problem = new MongoDBRef(ProblemsService.MongoDbCollectionName, "000000000000000000000003")
+            },
+            TestSetDataIssues.IndexNotContinuous
+        };
     }
 }
 
@@ -334,5 +401,6 @@ public enum TestSetDataIssues
     IndexNotUnique = 1 << 6,
     MissingValueAsJson = 1 << 7,
     ValueDoesNotMatchDataType = 1 << 8,
-    ValueCannotBeDeserialized = 1 << 9
+    ValueCannotBeDeserialized = 1 << 9,
+    IndexNotContinuous = 1 << 10
 }

--- a/src/Tsa.Submissions.Coding.UnitTests/Data/TestSetsTestData.cs
+++ b/src/Tsa.Submissions.Coding.UnitTests/Data/TestSetsTestData.cs
@@ -1,12 +1,14 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using MongoDB.Driver;
 using Tsa.Submissions.Coding.WebApi.Entities;
 using Tsa.Submissions.Coding.WebApi.Services;
 
 namespace Tsa.Submissions.Coding.UnitTests.Data;
 
+[ExcludeFromCodeCoverage]
 public class TestSetsTestData : IEnumerable<object[]>
 {
     IEnumerator IEnumerable.GetEnumerator()

--- a/src/Tsa.Submissions.Coding.UnitTests/Data/TestSetsTestData.cs
+++ b/src/Tsa.Submissions.Coding.UnitTests/Data/TestSetsTestData.cs
@@ -71,11 +71,65 @@ public class TestSetsTestData : IEnumerable<object[]>
             },
             TestSetDataIssues.None
         };
+
+        yield return new object[]
+        {
+            new TestSet
+            {
+                Id = "000000000000000000000003",
+                Inputs = new List<TestSetInput>
+                {
+                    new()
+                    {
+                        DataType = "string",
+                        Index = 0,
+                        ValueAsJson = "test value"
+                    },
+                    new()
+                    {
+                        DataType = "number",
+                        Index = 1,
+                        ValueAsJson = "1"
+                    }
+                },
+                IsPublic = true,
+                Problem = new MongoDBRef(ProblemsService.MongoDbCollectionName, "000000000000000000000002")
+            },
+            TestSetDataIssues.MissingName
+        };
+
+        yield return new object[]
+        {
+            new TestSet
+            {
+                Id = "000000000000000000000004",
+                Inputs = new List<TestSetInput>
+                {
+                    new()
+                    {
+                        DataType = "string",
+                        Index = 0,
+                        ValueAsJson = "test value"
+                    },
+                    new()
+                    {
+                        DataType = "number",
+                        Index = 1,
+                        ValueAsJson = "1"
+                    }
+                },
+                IsPublic = true,
+                Name = "Test Set #4"
+            },
+            TestSetDataIssues.MissingProblemId
+        };
     }
 }
 
 [Flags]
 public enum TestSetDataIssues
 {
-    None = 0
+    None = 0,
+    MissingName = 1 << 0,
+    MissingProblemId = 1 << 1,
 }

--- a/src/Tsa.Submissions.Coding.UnitTests/Data/TestSetsTestData.cs
+++ b/src/Tsa.Submissions.Coding.UnitTests/Data/TestSetsTestData.cs
@@ -135,6 +135,189 @@ public class TestSetsTestData : IEnumerable<object[]>
             },
             TestSetDataIssues.MissingInput
         };
+
+        yield return new object[]
+        {
+            new TestSet
+            {
+                Id = "000000000000000000000006",
+                Inputs = new List<TestSetInput>
+                {
+                    new()
+                    {
+                        Index = 0,
+                        ValueAsJson = "{ \"value\": \"test value\" }"
+                    },
+                    new()
+                    {
+                        Index = 1,
+                        ValueAsJson = "{ \"value\": 1 }"
+                    }
+                },
+                IsPublic = true,
+                Name = "Test Set #6",
+                Problem = new MongoDBRef(ProblemsService.MongoDbCollectionName, "000000000000000000000003")
+            },
+            TestSetDataIssues.MissingDataType
+        };
+
+        yield return new object[]
+        {
+            new TestSet
+            {
+                Id = "000000000000000000000007",
+                Inputs = new List<TestSetInput>
+                {
+                    new()
+                    {
+                        DataType = "dog",
+                        Index = 0,
+                        ValueAsJson = "{ \"value\": \"test value\" }"
+                    },
+                    new()
+                    {
+                        DataType = "cat",
+                        Index = 1,
+                        ValueAsJson = "{ \"value\": 1 }"
+                    }
+                },
+                IsPublic = true,
+                Name = "Test Set #7",
+                Problem = new MongoDBRef(ProblemsService.MongoDbCollectionName, "000000000000000000000003")
+            },
+            TestSetDataIssues.InvalidDataType
+        };
+
+        yield return new object[]
+        {
+            new TestSet
+            {
+                Id = "000000000000000000000008",
+                Inputs = new List<TestSetInput>
+                {
+                    new()
+                    {
+                        DataType = "string",
+                        ValueAsJson = "{ \"value\": \"test value\" }"
+                    },
+                    new()
+                    {
+                        DataType = "number",
+                        ValueAsJson = "{ \"value\": 1 }"
+                    }
+                },
+                IsPublic = true,
+                Name = "Test Set #8",
+                Problem = new MongoDBRef(ProblemsService.MongoDbCollectionName, "000000000000000000000003")
+            },
+            TestSetDataIssues.MissingIndex
+        };
+
+        yield return new object[]
+        {
+            new TestSet
+            {
+                Id = "000000000000000000000009",
+                Inputs = new List<TestSetInput>
+                {
+                    new()
+                    {
+                        DataType = "string",
+                        Index = 0,
+                        ValueAsJson = "{ \"value\": \"test value\" }"
+                    },
+                    new()
+                    {
+                        DataType = "number",
+                        Index = 0,
+                        ValueAsJson = "{ \"value\": 1 }"
+                    }
+                },
+                IsPublic = true,
+                Name = "Test Set #2",
+                Problem = new MongoDBRef(ProblemsService.MongoDbCollectionName, "000000000000000000000003")
+            },
+            TestSetDataIssues.IndexNotUnique
+        };
+
+        yield return new object[]
+        {
+            new TestSet
+            {
+                Id = "000000000000000000000010",
+                Inputs = new List<TestSetInput>
+                {
+                    new()
+                    {
+                        DataType = "string",
+                        Index = 0
+                    },
+                    new()
+                    {
+                        DataType = "number",
+                        Index = 1
+                    }
+                },
+                IsPublic = true,
+                Name = "Test Set #10",
+                Problem = new MongoDBRef(ProblemsService.MongoDbCollectionName, "000000000000000000000003")
+            },
+            TestSetDataIssues.MissingValueAsJson
+        };
+
+        yield return new object[]
+        {
+            new TestSet
+            {
+                Id = "000000000000000000000011",
+                Inputs = new List<TestSetInput>
+                {
+                    new()
+                    {
+                        DataType = "number",
+                        Index = 0,
+                        ValueAsJson = "{ \"value\": \"test value\" }"
+                    },
+                    new()
+                    {
+                        DataType = "number",
+                        Index = 1,
+                        ValueAsJson = "{ \"value\": 1 }"
+                    }
+                },
+                IsPublic = true,
+                Name = "Test Set #11",
+                Problem = new MongoDBRef(ProblemsService.MongoDbCollectionName, "000000000000000000000003")
+            },
+            TestSetDataIssues.ValueDoesNotMatchDataType
+        };
+
+        yield return new object[]
+        {
+            new TestSet
+            {
+                Id = "000000000000000000000012",
+                Inputs = new List<TestSetInput>
+                {
+                    new()
+                    {
+                        DataType = "string",
+                        Index = 0,
+                        ValueAsJson = "Try me"
+                    },
+                    new()
+                    {
+                        DataType = "number",
+                        Index = 1,
+                        ValueAsJson = "Try me"
+                    }
+                },
+                IsPublic = true,
+                Name = "Test Set #12",
+                Problem = new MongoDBRef(ProblemsService.MongoDbCollectionName, "000000000000000000000003")
+            },
+            TestSetDataIssues.ValueCannotBeDeserialized
+        };
     }
 }
 
@@ -144,5 +327,12 @@ public enum TestSetDataIssues
     None = 0,
     MissingName = 1 << 0,
     MissingProblemId = 1 << 1,
-    MissingInput = 1 << 2
+    MissingInput = 1 << 2,
+    MissingDataType = 1 << 3,
+    InvalidDataType = 1 << 4,
+    MissingIndex = 1 << 5,
+    IndexNotUnique = 1 << 6,
+    MissingValueAsJson = 1 << 7,
+    ValueDoesNotMatchDataType = 1 << 8,
+    ValueCannotBeDeserialized = 1 << 9
 }

--- a/src/Tsa.Submissions.Coding.UnitTests/Data/TestSetsTestData.cs
+++ b/src/Tsa.Submissions.Coding.UnitTests/Data/TestSetsTestData.cs
@@ -29,13 +29,13 @@ public class TestSetsTestData : IEnumerable<object[]>
                     {
                         DataType = "string",
                         Index = 0,
-                        ValueAsJson = "test value"
+                        ValueAsJson = "{ \"value\": \"test value\" }"
                     },
                     new()
                     {
                         DataType = "number",
                         Index = 1,
-                        ValueAsJson = "1"
+                        ValueAsJson = "{ \"value\": 1 }"
                     }
                 },
                 IsPublic = true,
@@ -56,13 +56,13 @@ public class TestSetsTestData : IEnumerable<object[]>
                     {
                         DataType = "string",
                         Index = 0,
-                        ValueAsJson = "test value"
+                        ValueAsJson = "{ \"value\": \"test value\" }"
                     },
                     new()
                     {
                         DataType = "number",
                         Index = 1,
-                        ValueAsJson = "1"
+                        ValueAsJson = "{ \"value\": 1 }"
                     }
                 },
                 IsPublic = true,
@@ -83,13 +83,13 @@ public class TestSetsTestData : IEnumerable<object[]>
                     {
                         DataType = "string",
                         Index = 0,
-                        ValueAsJson = "test value"
+                        ValueAsJson = "{ \"value\": \"test value\" }"
                     },
                     new()
                     {
                         DataType = "number",
                         Index = 1,
-                        ValueAsJson = "1"
+                        ValueAsJson = "{ \"value\": 1 }"
                     }
                 },
                 IsPublic = true,
@@ -109,19 +109,31 @@ public class TestSetsTestData : IEnumerable<object[]>
                     {
                         DataType = "string",
                         Index = 0,
-                        ValueAsJson = "test value"
+                        ValueAsJson = "{ \"value\": \"test value\" }"
                     },
                     new()
                     {
                         DataType = "number",
                         Index = 1,
-                        ValueAsJson = "1"
+                        ValueAsJson = "{ \"value\": 1 }"
                     }
                 },
                 IsPublic = true,
                 Name = "Test Set #4"
             },
             TestSetDataIssues.MissingProblemId
+        };
+
+        yield return new object[]
+        {
+            new TestSet
+            {
+                Id = "000000000000000000000005",
+                IsPublic = true,
+                Name = "Test Set #5",
+                Problem = new MongoDBRef(ProblemsService.MongoDbCollectionName, "000000000000000000000002")
+            },
+            TestSetDataIssues.MissingInput
         };
     }
 }
@@ -132,4 +144,5 @@ public enum TestSetDataIssues
     None = 0,
     MissingName = 1 << 0,
     MissingProblemId = 1 << 1,
+    MissingInput = 1 << 2
 }

--- a/src/Tsa.Submissions.Coding.UnitTests/Helpers/ProblemEqualityComparer.cs
+++ b/src/Tsa.Submissions.Coding.UnitTests/Helpers/ProblemEqualityComparer.cs
@@ -1,0 +1,52 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Tsa.Submissions.Coding.WebApi.Entities;
+
+namespace Tsa.Submissions.Coding.UnitTests.Helpers;
+
+//TODO: Turn into code generator
+[ExcludeFromCodeCoverage]
+internal class ProblemEqualityComparer : IEqualityComparer<Problem?>, IEqualityComparer<IList<Problem>?>
+{
+    public bool Equals(Problem? x, Problem? y)
+    {
+        if (x == null && y == null) return true;
+
+        if (x == null || y == null) return false;
+
+        var descriptionsMatch = x.Description == y.Description;
+        var idsMatch = x.Id == y.Id;
+        var isActiveMatch = x.IsActive == y.IsActive;
+        var titlesMatch = x.Title == y.Title;
+
+        return descriptionsMatch && idsMatch && isActiveMatch && titlesMatch;
+    }
+
+    public bool Equals(IList<Problem>? x, IList<Problem>? y)
+    {
+        if (ReferenceEquals(x, y)) return true;
+        if (x is null) return false;
+        if (y is null) return false;
+        if (x.Count != y.Count) return false;
+
+        foreach (var leftProblem in x)
+        {
+            var rightProblem = y.SingleOrDefault(_ => _.Id == leftProblem.Id);
+
+            if (!Equals(leftProblem, rightProblem)) return false;
+        }
+
+        return true;
+    }
+
+    public int GetHashCode(Problem? obj)
+    {
+        return obj == null ? 0 : obj.GetHashCode();
+    }
+
+    public int GetHashCode(IList<Problem>? obj)
+    {
+        return obj == null ? 0 : obj.GetHashCode();
+    }
+}

--- a/src/Tsa.Submissions.Coding.UnitTests/Helpers/ProblemEqualityComparer.cs
+++ b/src/Tsa.Submissions.Coding.UnitTests/Helpers/ProblemEqualityComparer.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+using Tsa.Submissions.Coding.WebApi.Entities;
+
+namespace Tsa.Submissions.Coding.UnitTests.Helpers;
+
+internal class ProblemEqualityComparer : IEqualityComparer<Problem>
+{
+    public bool Equals(Problem? x, Problem? y)
+    {
+        return x?.Id == y?.Id;
+    }
+
+    public int GetHashCode(Problem obj)
+    {
+        return obj.GetHashCode();
+    }
+}

--- a/src/Tsa.Submissions.Coding.UnitTests/Helpers/ProblemEqualityComparer.cs
+++ b/src/Tsa.Submissions.Coding.UnitTests/Helpers/ProblemEqualityComparer.cs
@@ -11,9 +11,9 @@ internal class ProblemEqualityComparer : IEqualityComparer<Problem?>, IEqualityC
 {
     public bool Equals(Problem? x, Problem? y)
     {
-        if (x == null && y == null) return true;
-
-        if (x == null || y == null) return false;
+        if (ReferenceEquals(x, y)) return true;
+        if (x is null) return false;
+        if (y is null) return false;
 
         var descriptionsMatch = x.Description == y.Description;
         var idsMatch = x.Id == y.Id;

--- a/src/Tsa.Submissions.Coding.UnitTests/Helpers/ProblemModelEqualityComparer.cs
+++ b/src/Tsa.Submissions.Coding.UnitTests/Helpers/ProblemModelEqualityComparer.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Tsa.Submissions.Coding.WebApi.Models;
+
+namespace Tsa.Submissions.Coding.UnitTests.Helpers;
+
+//TODO: Turn into code generator
+[ExcludeFromCodeCoverage]
+internal class ProblemModelEqualityComparer : IEqualityComparer<ProblemModel?>, IEqualityComparer<IList<ProblemModel>?>
+{
+    private readonly TestSetModelEqualityComparer _testSetModelEqualityComparer = new();
+
+    public bool Equals(ProblemModel? x, ProblemModel? y)
+    {
+        if (ReferenceEquals(x, y)) return true;
+        if (ReferenceEquals(x, null)) return false;
+        if (ReferenceEquals(y, null)) return false;
+        if (x.GetType() != y.GetType()) return false;
+
+        return
+            x.Description == y.Description &&
+            x.Id == y.Id &&
+            x.IsActive == y.IsActive &&
+            _testSetModelEqualityComparer.Equals(x.TestSets, y.TestSets) &&
+            x.Title == y.Title;
+    }
+
+    public bool Equals(IList<ProblemModel>? x, IList<ProblemModel>? y)
+    {
+        if (ReferenceEquals(x, y)) return true;
+        if (x is null) return false;
+        if (y is null) return false;
+        if (x.Count != y.Count) return false;
+
+        foreach (var leftProblemModel in x)
+        {
+            var rightProblemModel = y.SingleOrDefault(_ => _.Id == leftProblemModel.Id);
+
+            if (!Equals(leftProblemModel, rightProblemModel)) return false;
+        }
+
+        return true;
+    }
+
+    public int GetHashCode(ProblemModel obj)
+    {
+        return HashCode.Combine(obj.Description, obj.Id, obj.IsActive, obj.TestSets, obj.Title);
+    }
+
+    public int GetHashCode(IList<ProblemModel>? obj)
+    {
+        return obj == null ? 0 : obj.GetHashCode();
+    }
+}

--- a/src/Tsa.Submissions.Coding.UnitTests/Helpers/ProblemModelEqualityComparer.cs
+++ b/src/Tsa.Submissions.Coding.UnitTests/Helpers/ProblemModelEqualityComparer.cs
@@ -15,8 +15,8 @@ internal class ProblemModelEqualityComparer : IEqualityComparer<ProblemModel?>, 
     public bool Equals(ProblemModel? x, ProblemModel? y)
     {
         if (ReferenceEquals(x, y)) return true;
-        if (ReferenceEquals(x, null)) return false;
-        if (ReferenceEquals(y, null)) return false;
+        if (x is null) return false;
+        if (y is null) return false;
         if (x.GetType() != y.GetType()) return false;
 
         return

--- a/src/Tsa.Submissions.Coding.UnitTests/Helpers/StringEqualityComparer.cs
+++ b/src/Tsa.Submissions.Coding.UnitTests/Helpers/StringEqualityComparer.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Tsa.Submissions.Coding.UnitTests.Helpers;
+
+[ExcludeFromCodeCoverage]
+internal class StringEqualityComparer : IEqualityComparer<string?>
+{
+    public bool Equals(string? x, string? y)
+    {
+        return string.Equals(x, y, StringComparison.InvariantCultureIgnoreCase);
+    }
+
+    public int GetHashCode(string? obj)
+    {
+        return obj == null ? 0 : obj.GetHashCode(StringComparison.InvariantCultureIgnoreCase);
+    }
+}

--- a/src/Tsa.Submissions.Coding.UnitTests/Helpers/TestSetInputModelEqualityComparer.cs
+++ b/src/Tsa.Submissions.Coding.UnitTests/Helpers/TestSetInputModelEqualityComparer.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Tsa.Submissions.Coding.WebApi.Models;
+
+namespace Tsa.Submissions.Coding.UnitTests.Helpers;
+
+//TODO: Turn into code generator
+[ExcludeFromCodeCoverage]
+internal class TestSetInputModelEqualityComparer : IEqualityComparer<TestSetInputModel?>, IEqualityComparer<IList<TestSetInputModel>?>
+{
+    public bool Equals(TestSetInputModel? x, TestSetInputModel? y)
+    {
+        if (ReferenceEquals(x, y)) return true;
+        if (ReferenceEquals(x, null)) return false;
+        if (ReferenceEquals(y, null)) return false;
+        if (x.GetType() != y.GetType()) return false;
+
+        return
+            x.DataType == y.DataType &&
+            x.Index == y.Index &&
+            x.IsArray == y.IsArray &&
+            x.ValueAsJson == y.ValueAsJson;
+    }
+
+    public bool Equals(IList<TestSetInputModel>? x, IList<TestSetInputModel>? y)
+    {
+        if (ReferenceEquals(x, y)) return true;
+        if (ReferenceEquals(x, null)) return false;
+        if (ReferenceEquals(y, null)) return false;
+        if (x.Count != y.Count) return false;
+
+        foreach (var leftTestInputModel in x)
+        {
+            var rightTestSetInputModel = y.SingleOrDefault(_ => _.Index == leftTestInputModel.Index);
+
+            if (!Equals(leftTestInputModel, rightTestSetInputModel)) return false;
+        }
+
+        return true;
+    }
+
+    public int GetHashCode(TestSetInputModel obj)
+    {
+        return HashCode.Combine(obj.DataType, obj.Index, obj.IsArray, obj.ValueAsJson);
+    }
+
+    public int GetHashCode(IList<TestSetInputModel>? obj)
+    {
+        return obj == null ? 0 : obj.GetHashCode();
+    }
+}

--- a/src/Tsa.Submissions.Coding.UnitTests/Helpers/TestSetInputModelEqualityComparer.cs
+++ b/src/Tsa.Submissions.Coding.UnitTests/Helpers/TestSetInputModelEqualityComparer.cs
@@ -13,8 +13,8 @@ internal class TestSetInputModelEqualityComparer : IEqualityComparer<TestSetInpu
     public bool Equals(TestSetInputModel? x, TestSetInputModel? y)
     {
         if (ReferenceEquals(x, y)) return true;
-        if (ReferenceEquals(x, null)) return false;
-        if (ReferenceEquals(y, null)) return false;
+        if (x is null) return false;
+        if (y is null) return false;
         if (x.GetType() != y.GetType()) return false;
 
         return
@@ -27,8 +27,8 @@ internal class TestSetInputModelEqualityComparer : IEqualityComparer<TestSetInpu
     public bool Equals(IList<TestSetInputModel>? x, IList<TestSetInputModel>? y)
     {
         if (ReferenceEquals(x, y)) return true;
-        if (ReferenceEquals(x, null)) return false;
-        if (ReferenceEquals(y, null)) return false;
+        if (x is null) return false;
+        if (y is null) return false;
         if (x.Count != y.Count) return false;
 
         foreach (var leftTestInputModel in x)

--- a/src/Tsa.Submissions.Coding.UnitTests/Helpers/TestSetModelEqualityComparer.cs
+++ b/src/Tsa.Submissions.Coding.UnitTests/Helpers/TestSetModelEqualityComparer.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Tsa.Submissions.Coding.WebApi.Models;
+
+namespace Tsa.Submissions.Coding.UnitTests.Helpers;
+
+//TODO: Turn into code generator
+[ExcludeFromCodeCoverage]
+internal class TestSetModelEqualityComparer : IEqualityComparer<TestSetModel?>, IEqualityComparer<IList<TestSetModel>?>
+{
+    private readonly TestSetInputModelEqualityComparer _testSetInputModelEqualityComparer = new();
+
+    public bool Equals(TestSetModel? x, TestSetModel? y)
+    {
+        if (ReferenceEquals(x, y)) return true;
+        if (x is null) return false;
+        if (y is null) return false;
+        if (x.GetType() != y.GetType()) return false;
+
+        return
+            x.Id == y.Id &&
+            _testSetInputModelEqualityComparer.Equals(x.Inputs, y.Inputs) &&
+            x.IsPublic == y.IsPublic &&
+            x.Name == y.Name &&
+            x.ProblemId == y.ProblemId;
+    }
+
+    public bool Equals(IList<TestSetModel>? x, IList<TestSetModel>? y)
+    {
+        if (ReferenceEquals(x, y)) return true;
+        if (x is null) return false;
+        if (y is null) return false;
+        if (x.Count != y.Count) return false;
+
+        foreach (var leftTestInputModel in x)
+        {
+            var rightTestSetInputModel = y.SingleOrDefault(_ => _.Id == leftTestInputModel.Id);
+
+            if (!Equals(leftTestInputModel, rightTestSetInputModel)) return false;
+        }
+
+        return true;
+    }
+
+    public int GetHashCode(TestSetModel obj)
+    {
+        return HashCode.Combine(obj.Id, obj.Inputs, obj.IsPublic, obj.Name, obj.ProblemId);
+    }
+
+    public int GetHashCode(IList<TestSetModel>? obj)
+    {
+        return obj == null ? 0 : obj.GetHashCode();
+    }
+}

--- a/src/Tsa.Submissions.Coding.UnitTests/WebApi/Controllers/ProblemsControllerTests.cs
+++ b/src/Tsa.Submissions.Coding.UnitTests/WebApi/Controllers/ProblemsControllerTests.cs
@@ -3,10 +3,14 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
+using System.Security.Claims;
+using System.Security.Principal;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
 using Tsa.Submissions.Coding.UnitTests.Data;
+using Tsa.Submissions.Coding.UnitTests.Helpers;
 using Tsa.Submissions.Coding.WebApi.Authorization;
 using Tsa.Submissions.Coding.WebApi.Controllers;
 using Tsa.Submissions.Coding.WebApi.Entities;
@@ -189,7 +193,7 @@ public class ProblemsControllerTests
         var problemsController = new ProblemsController(mockedProblemsService.Object, mockedTestSetsService.Object);
 
         // Act
-        var actionResult = await problemsController.Delete("64639f6fcdde06187b09ecae", default);
+        var actionResult = await problemsController.Delete("64639f6fcdde06187b09ecae");
 
         // Assert
         Assert.NotNull(actionResult);
@@ -208,7 +212,7 @@ public class ProblemsControllerTests
         var problemsController = new ProblemsController(mockedProblemsService.Object, mockedTestSetsService.Object);
 
         // Act
-        var actionResult = await problemsController.Delete("64639f6fcdde06187b09ecae", default);
+        var actionResult = await problemsController.Delete("64639f6fcdde06187b09ecae");
 
         // Assert
         Assert.NotNull(actionResult);
@@ -257,10 +261,132 @@ public class ProblemsControllerTests
         // Assert
         Assert.NotNull(actionResult);
         Assert.NotNull(actionResult.Value);
-        Assert.Equal(problem!.Description, actionResult.Value!.Description);
-        Assert.Equal(problem.Id, actionResult.Value.Id);
-        Assert.Equal(problem.IsActive, actionResult.Value.IsActive);
-        Assert.Equal(problem.Title, actionResult.Value.Title);
+        Assert.Equal(problem!.ToModel(), actionResult.Value, new ProblemModelEqualityComparer());
+    }
+
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public async void Get_By_Id_Should_Return_Ok_With_Test_Sets_Expanded_For_Judge()
+    {
+        // Arrange
+        var problemsTestData = new ProblemsTestData();
+
+        var problem = problemsTestData.First(_ => (ProblemDataIssues)_[1] == ProblemDataIssues.None)[0] as Problem;
+
+        var problemId = problem!.Id;
+
+        var testSetsTestData = new TestSetsTestData();
+
+        var testSetList = testSetsTestData
+            .Where(_ => (TestSetDataIssues)_[1] == TestSetDataIssues.None &&
+                        ((TestSet)_[0]).Problem?.Id.AsString == problemId)
+            .Select(_ => _[0])
+            .Cast<TestSet>()
+            .ToList();
+
+        var expectedProblemModel = problem.ToModel();
+        expectedProblemModel.TestSets = testSetList.ToModels();
+
+        var mockedProblemsService = new Mock<IProblemsService>();
+        mockedProblemsService
+            .Setup(_ => _.GetAsync(It.Is(problemId, new StringEqualityComparer())!, default))
+            .ReturnsAsync(problem);
+
+        var mockedTestSetsService = new Mock<ITestSetsService>();
+        mockedTestSetsService.Setup(_ => _.GetAsync(It.Is(problem, new ProblemEqualityComparer()), default))
+            .ReturnsAsync(testSetList);
+
+        var identityMock = new Mock<IIdentity>();
+        identityMock.Setup(i => i.Name).Returns("0000-000");
+
+        var claimsPrincipalMock = new Mock<ClaimsPrincipal>();
+        claimsPrincipalMock.Setup(cp => cp.Identity).Returns(identityMock.Object);
+        claimsPrincipalMock.Setup(cp => cp.IsInRole(It.IsAny<string>())).Returns(false);
+
+        var httpContext = new DefaultHttpContext
+        {
+            User = claimsPrincipalMock.Object
+        };
+
+        var problemsController = new ProblemsController(mockedProblemsService.Object, mockedTestSetsService.Object)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext
+            }
+        };
+
+        // Act
+        var actionResult = await problemsController.Get(problemId!, true);
+
+        // Assert
+        Assert.NotNull(actionResult);
+        Assert.NotNull(actionResult.Value);
+        Assert.Equal(expectedProblemModel, actionResult.Value, new ProblemModelEqualityComparer());
+    }
+
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public async void Get_By_Id_Should_Return_Ok_With_Test_Sets_Expanded_For_Participant()
+    {
+        // Arrange
+        var problemsTestData = new ProblemsTestData();
+
+        var problem = problemsTestData.First(_ => (ProblemDataIssues)_[1] == ProblemDataIssues.None)[0] as Problem;
+
+        var problemId = problem!.Id;
+
+        var testSetsTestData = new TestSetsTestData();
+
+        var testSetList = testSetsTestData
+            .Where(_ => (TestSetDataIssues)_[1] == TestSetDataIssues.None &&
+                        ((TestSet)_[0]).Problem?.Id.AsString == problemId)
+            .Select(_ => _[0])
+            .Cast<TestSet>()
+            .ToList();
+
+        var expectedProblemModel = problem.ToModel();
+        expectedProblemModel.TestSets = testSetList
+            .Where(_ => _.IsPublic)
+            .ToList()
+            .ToModels();
+
+        var mockedProblemsService = new Mock<IProblemsService>();
+        mockedProblemsService
+            .Setup(_ => _.GetAsync(It.Is(problemId, new StringEqualityComparer())!, default))
+            .ReturnsAsync(problem);
+
+        var mockedTestSetsService = new Mock<ITestSetsService>();
+        mockedTestSetsService.Setup(_ => _.GetAsync(It.Is(problem, new ProblemEqualityComparer()), default))
+            .ReturnsAsync(testSetList);
+
+        var identityMock = new Mock<IIdentity>();
+        identityMock.Setup(i => i.Name).Returns("0000-000");
+
+        var claimsPrincipalMock = new Mock<ClaimsPrincipal>();
+        claimsPrincipalMock.Setup(cp => cp.Identity).Returns(identityMock.Object);
+        claimsPrincipalMock.Setup(cp => cp.IsInRole(It.IsAny<string>())).Returns(true);
+
+        var httpContext = new DefaultHttpContext
+        {
+            User = claimsPrincipalMock.Object
+        };
+
+        var problemsController = new ProblemsController(mockedProblemsService.Object, mockedTestSetsService.Object)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext
+            }
+        };
+
+        // Act
+        var actionResult = await problemsController.Get(problemId!, true);
+
+        // Assert
+        Assert.NotNull(actionResult);
+        Assert.NotNull(actionResult.Value);
+        Assert.Equal(expectedProblemModel, actionResult.Value, new ProblemModelEqualityComparer());
     }
 
     [Fact]
@@ -316,6 +442,396 @@ public class ProblemsControllerTests
         Assert.NotNull(actionResult.Value);
         Assert.NotEmpty(actionResult.Value!);
         Assert.Equal(problemsList.Count, actionResult.Value!.Count);
+        Assert.Equal(problemsList.ToModels(), actionResult.Value, new ProblemModelEqualityComparer());
+    }
+
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public async void Get_Should_Return_Ok_With_Test_Sets_Expanded_For_Judge()
+    {
+        // Arrange
+        var problemsTestData = new ProblemsTestData();
+
+        var problemsList = problemsTestData
+            .Where(_ => (ProblemDataIssues)_[1] == ProblemDataIssues.None)
+            .Select(_ => _[0])
+            .Cast<Problem>()
+            .ToList();
+
+        var testSetsTestData = new TestSetsTestData();
+
+        var testSetList = testSetsTestData
+            .Where(_ => (TestSetDataIssues)_[1] == TestSetDataIssues.None)
+            .Select(_ => _[0])
+            .Cast<TestSet>()
+            .ToList();
+
+        var expectedProblemModels = problemsList.ToModels();
+
+        foreach (var expectedProblemModel in expectedProblemModels)
+        {
+            expectedProblemModel.TestSets = testSetList
+                .ToModels()
+                .Where(_ => _.ProblemId == expectedProblemModel.Id)
+                .ToList();
+        }
+
+        var mockedProblemsService = new Mock<IProblemsService>();
+        mockedProblemsService.Setup(_ => _.GetAsync(default))
+            .ReturnsAsync(problemsList);
+
+        var mockedTestSetsService = new Mock<ITestSetsService>();
+
+        foreach (var problem in problemsList)
+        {
+            var testSets = testSetList.Where(_ => _.Problem?.Id == problem.Id).ToList();
+
+            mockedTestSetsService
+                .Setup(_ => _.GetAsync(It.Is(problem, new ProblemEqualityComparer()), default))
+                .ReturnsAsync(testSets);
+        }
+
+        var identityMock = new Mock<IIdentity>();
+        identityMock.Setup(i => i.Name).Returns("0000-000");
+
+        var claimsPrincipalMock = new Mock<ClaimsPrincipal>();
+        claimsPrincipalMock.Setup(cp => cp.Identity).Returns(identityMock.Object);
+        claimsPrincipalMock.Setup(cp => cp.IsInRole(It.IsAny<string>())).Returns(false);
+
+        var httpContext = new DefaultHttpContext
+        {
+            User = claimsPrincipalMock.Object
+        };
+
+        var problemsController = new ProblemsController(mockedProblemsService.Object, mockedTestSetsService.Object)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext
+            }
+        };
+
+        // Act
+        var actionResult = await problemsController.Get(true);
+
+        // Assert
+        Assert.NotNull(actionResult);
+        Assert.NotNull(actionResult.Value);
+        Assert.NotEmpty(actionResult.Value!);
+        Assert.Equal(expectedProblemModels.Count, actionResult.Value!.Count);
+        Assert.Equal(expectedProblemModels, actionResult.Value, new ProblemModelEqualityComparer());
+    }
+
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public async void Get_Should_Return_Ok_With_Test_Sets_Expanded_For_Participant()
+    {
+        // Arrange
+        var problemsTestData = new ProblemsTestData();
+
+        var problemsList = problemsTestData
+            .Where(_ => (ProblemDataIssues)_[1] == ProblemDataIssues.None)
+            .Select(_ => _[0])
+            .Cast<Problem>()
+            .ToList();
+
+        var testSetsTestData = new TestSetsTestData();
+
+        var testSetList = testSetsTestData
+            .Where(_ => (TestSetDataIssues)_[1] == TestSetDataIssues.None)
+            .Select(_ => _[0])
+            .Cast<TestSet>()
+            .ToList();
+
+        var expectedProblemModels = problemsList.ToModels();
+
+        foreach (var expectedProblemModel in expectedProblemModels)
+        {
+            expectedProblemModel.TestSets = testSetList
+                .ToModels()
+                .Where(_ => _.ProblemId == expectedProblemModel.Id && _.IsPublic)
+                .ToList();
+        }
+
+        var mockedProblemsService = new Mock<IProblemsService>();
+        mockedProblemsService.Setup(_ => _.GetAsync(default))
+            .ReturnsAsync(problemsList);
+
+        var mockedTestSetsService = new Mock<ITestSetsService>();
+
+        foreach (var problem in problemsList)
+        {
+            var testSets = testSetList.Where(_ => _.Problem?.Id == problem.Id).ToList();
+
+            mockedTestSetsService
+                .Setup(_ => _.GetAsync(It.Is(problem, new ProblemEqualityComparer()), default))
+                .ReturnsAsync(testSets);
+        }
+
+        var identityMock = new Mock<IIdentity>();
+        identityMock.Setup(i => i.Name).Returns("0000-000");
+
+        var claimsPrincipalMock = new Mock<ClaimsPrincipal>();
+        claimsPrincipalMock.Setup(cp => cp.Identity).Returns(identityMock.Object);
+        claimsPrincipalMock.Setup(cp => cp.IsInRole(It.IsAny<string>())).Returns(true);
+
+        var httpContext = new DefaultHttpContext
+        {
+            User = claimsPrincipalMock.Object
+        };
+
+        var problemsController = new ProblemsController(mockedProblemsService.Object, mockedTestSetsService.Object)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext
+            }
+        };
+
+        // Act
+        var actionResult = await problemsController.Get(true);
+
+        // Assert
+        Assert.NotNull(actionResult);
+        Assert.NotNull(actionResult.Value);
+        Assert.NotEmpty(actionResult.Value!);
+        Assert.Equal(expectedProblemModels.Count, actionResult.Value!.Count);
+        Assert.Equal(expectedProblemModels, actionResult.Value, new ProblemModelEqualityComparer());
+    }
+
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public async void GetTestSets_Should_Return_Not_Found()
+    {
+        // Arrange
+        var mockedProblemsService = new Mock<IProblemsService>();
+
+        var mockedTestSetsService = new Mock<ITestSetsService>();
+
+        var problemsController = new ProblemsController(mockedProblemsService.Object, mockedTestSetsService.Object);
+
+        // Act
+        var actionResult = await problemsController.GetTestSets("64639f6fcdde06187b09ecae");
+
+        // Assert
+        Assert.NotNull(actionResult);
+        Assert.IsType<NotFoundResult>(actionResult.Result);
+    }
+
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public async void GetTestSets_Should_Return_Ok_When_Empty_For_Judge()
+    {
+        // Arrange
+        var testSetsTestData = new TestSetsTestData();
+
+        var problemId = ((TestSet)testSetsTestData.First(_ => (TestSetDataIssues)_[1] == TestSetDataIssues.None)[0]).Problem?.Id.AsString;
+
+        var problem = new Problem { Id = problemId };
+
+        var testSetList = new List<TestSet>();
+
+        var mockedProblemsService = new Mock<IProblemsService>();
+        mockedProblemsService
+            .Setup(_ => _.GetAsync(It.Is(problemId, new StringEqualityComparer())!, default))
+            .ReturnsAsync(problem);
+
+        var mockedTestSetsService = new Mock<ITestSetsService>();
+        mockedTestSetsService.Setup(_ => _.GetAsync(It.Is(problem, new ProblemEqualityComparer()), default))
+            .ReturnsAsync(testSetList);
+
+        var identityMock = new Mock<IIdentity>();
+        identityMock.Setup(i => i.Name).Returns("0000-000");
+
+        var claimsPrincipalMock = new Mock<ClaimsPrincipal>();
+        claimsPrincipalMock.Setup(cp => cp.Identity).Returns(identityMock.Object);
+        claimsPrincipalMock.Setup(cp => cp.IsInRole(It.IsAny<string>())).Returns(false);
+
+        var httpContext = new DefaultHttpContext
+        {
+            User = claimsPrincipalMock.Object
+        };
+
+        var problemsController = new ProblemsController(mockedProblemsService.Object, mockedTestSetsService.Object)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext
+            }
+        };
+
+        // Act
+        var actionResult = await problemsController.GetTestSets(problemId!);
+
+        Assert.NotNull(actionResult);
+        Assert.NotNull(actionResult.Value);
+        Assert.Empty(actionResult.Value!);
+    }
+
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public async void GetTestSets_Should_Return_Ok_When_Empty_For_Participant()
+    {
+        // Arrange
+        var testSetsTestData = new TestSetsTestData();
+
+        var problemId = ((TestSet)testSetsTestData.First(_ => (TestSetDataIssues)_[1] == TestSetDataIssues.None)[0]).Problem?.Id.AsString;
+
+        var problem = new Problem { Id = problemId };
+
+        var testSetList = new List<TestSet>();
+
+        var mockedProblemsService = new Mock<IProblemsService>();
+        mockedProblemsService
+            .Setup(_ => _.GetAsync(It.Is(problemId, new StringEqualityComparer())!, default))
+            .ReturnsAsync(problem);
+
+        var mockedTestSetsService = new Mock<ITestSetsService>();
+        mockedTestSetsService.Setup(_ => _.GetAsync(It.Is(problem, new ProblemEqualityComparer()), default))
+            .ReturnsAsync(testSetList);
+
+        var identityMock = new Mock<IIdentity>();
+        identityMock.Setup(i => i.Name).Returns("0000-000");
+
+        var claimsPrincipalMock = new Mock<ClaimsPrincipal>();
+        claimsPrincipalMock.Setup(cp => cp.Identity).Returns(identityMock.Object);
+        claimsPrincipalMock.Setup(cp => cp.IsInRole(It.IsAny<string>())).Returns(true);
+
+        var httpContext = new DefaultHttpContext
+        {
+            User = claimsPrincipalMock.Object
+        };
+
+        var problemsController = new ProblemsController(mockedProblemsService.Object, mockedTestSetsService.Object)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext
+            }
+        };
+
+        // Act
+        var actionResult = await problemsController.GetTestSets(problemId!);
+
+        Assert.NotNull(actionResult);
+        Assert.NotNull(actionResult.Value);
+        Assert.Empty(actionResult.Value!);
+    }
+
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public async void GetTestSets_Should_Return_Ok_When_Not_Empty_For_Judge()
+    {
+        // Arrange
+        var testSetsTestData = new TestSetsTestData();
+
+        var problemId = ((TestSet)testSetsTestData.First(_ => (TestSetDataIssues)_[1] == TestSetDataIssues.None)[0]).Problem?.Id.AsString;
+
+        var problem = new Problem { Id = problemId };
+
+        var testSetList = testSetsTestData
+            .Where(_ => (TestSetDataIssues)_[1] == TestSetDataIssues.None &&
+                        ((TestSet)_[0]).Problem?.Id.AsString == problemId)
+            .Select(_ => _[0])
+            .Cast<TestSet>()
+            .ToList();
+
+        var mockedProblemsService = new Mock<IProblemsService>();
+        mockedProblemsService
+            .Setup(_ => _.GetAsync(It.Is(problemId, new StringEqualityComparer())!, default))
+            .ReturnsAsync(problem);
+
+        var mockedTestSetsService = new Mock<ITestSetsService>();
+        mockedTestSetsService.Setup(_ => _.GetAsync(It.Is(problem, new ProblemEqualityComparer()), default))
+            .ReturnsAsync(testSetList);
+
+        var identityMock = new Mock<IIdentity>();
+        identityMock.Setup(i => i.Name).Returns("0000-000");
+
+        var claimsPrincipalMock = new Mock<ClaimsPrincipal>();
+        claimsPrincipalMock.Setup(cp => cp.Identity).Returns(identityMock.Object);
+        claimsPrincipalMock.Setup(cp => cp.IsInRole(It.IsAny<string>())).Returns(false);
+
+        var httpContext = new DefaultHttpContext
+        {
+            User = claimsPrincipalMock.Object
+        };
+
+        var problemsController = new ProblemsController(mockedProblemsService.Object, mockedTestSetsService.Object)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext
+            }
+        };
+
+        // Act
+        var actionResult = await problemsController.GetTestSets(problemId!);
+
+        Assert.NotNull(actionResult);
+        Assert.NotNull(actionResult.Value);
+        Assert.NotEmpty(actionResult.Value!);
+        Assert.Equal(testSetList.Count, actionResult.Value!.Count);
+        Assert.Equal(testSetList.ToModels(), actionResult.Value, new TestSetModelEqualityComparer());
+    }
+
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public async void GetTestSets_Should_Return_Ok_When_Not_Empty_For_Participant()
+    {
+        // Arrange
+        var testSetsTestData = new TestSetsTestData();
+
+        var problemId = ((TestSet)testSetsTestData.First(_ => (TestSetDataIssues)_[1] == TestSetDataIssues.None)[0]).Problem?.Id.AsString;
+
+        var problem = new Problem { Id = problemId };
+
+        var testSetList = testSetsTestData
+            .Where(_ => (TestSetDataIssues)_[1] == TestSetDataIssues.None &&
+                        ((TestSet)_[0]).Problem?.Id.AsString == problemId)
+            .Select(_ => _[0])
+            .Cast<TestSet>()
+            .ToList();
+
+        var participantTestSetList = testSetList.Where(_ => _.IsPublic).ToList();
+
+        var mockedProblemsService = new Mock<IProblemsService>();
+        mockedProblemsService
+            .Setup(_ => _.GetAsync(It.Is(problemId, new StringEqualityComparer())!, default))
+            .ReturnsAsync(problem);
+
+        var mockedTestSetsService = new Mock<ITestSetsService>();
+        mockedTestSetsService.Setup(_ => _.GetAsync(It.Is(problem, new ProblemEqualityComparer()), default))
+            .ReturnsAsync(testSetList);
+
+        var identityMock = new Mock<IIdentity>();
+        identityMock.Setup(i => i.Name).Returns("0000-000");
+
+        var claimsPrincipalMock = new Mock<ClaimsPrincipal>();
+        claimsPrincipalMock.Setup(cp => cp.Identity).Returns(identityMock.Object);
+        claimsPrincipalMock.Setup(cp => cp.IsInRole(It.IsAny<string>())).Returns(true);
+
+        var httpContext = new DefaultHttpContext
+        {
+            User = claimsPrincipalMock.Object
+        };
+
+        var problemsController = new ProblemsController(mockedProblemsService.Object, mockedTestSetsService.Object)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext
+            }
+        };
+
+        // Act
+        var actionResult = await problemsController.GetTestSets(problemId!);
+
+        Assert.NotNull(actionResult);
+        Assert.NotNull(actionResult.Value);
+        Assert.NotEmpty(actionResult.Value!);
+        Assert.Equal(participantTestSetList.Count, actionResult.Value!.Count);
+        Assert.Equal(participantTestSetList.ToModels(), actionResult.Value, new TestSetModelEqualityComparer());
     }
 
     [Fact]
@@ -331,16 +847,6 @@ public class ProblemsControllerTests
             Title = "This is the title"
         };
 
-        Func<Problem, bool> validateProblem = problemToValidate =>
-        {
-            var descriptionsMatch = problemToValidate.Description == newProblem.Description;
-            var idsMatch = problemToValidate.Id == newProblem.Id;
-            var isActiveMatch = problemToValidate.IsActive == newProblem.IsActive;
-            var titlesMatch = problemToValidate.Title == newProblem.Title;
-
-            return descriptionsMatch && idsMatch && isActiveMatch && titlesMatch;
-        };
-
         var mockedProblemsService = new Mock<IProblemsService>();
 
         var mockedTestSetsService = new Mock<ITestSetsService>();
@@ -348,14 +854,14 @@ public class ProblemsControllerTests
         var problemsController = new ProblemsController(mockedProblemsService.Object, mockedTestSetsService.Object);
 
         // Act
-        var createdAtActionResult = await problemsController.Post(newProblem, default);
+        var createdAtActionResult = await problemsController.Post(newProblem);
 
         // Assert
         Assert.NotNull(createdAtActionResult);
 
         Assert.IsType<ProblemModel>(createdAtActionResult.Value);
 
-        mockedProblemsService.Verify(_ => _.CreateAsync(It.Is<Problem>(c => validateProblem(c)), default), Times.Once);
+        mockedProblemsService.Verify(_ => _.CreateAsync(It.Is(newProblem.ToEntity(), new ProblemEqualityComparer()), default), Times.Once);
     }
 
     [Fact]
@@ -375,31 +881,21 @@ public class ProblemsControllerTests
             Title = "This is the title"
         };
 
-        Func<Problem, bool> validateProblem = problemToValidate =>
-        {
-            var descriptionsMatch = problemToValidate.Description == updatedProblem.Description;
-            var idsMatch = problemToValidate.Id == updatedProblem.Id;
-            var isActiveMatch = problemToValidate.IsActive == updatedProblem.IsActive;
-            var titlesMatch = problemToValidate.Title == updatedProblem.Title;
-
-            return descriptionsMatch && idsMatch && isActiveMatch && titlesMatch;
-        };
-
         var mockedProblemsService = new Mock<IProblemsService>();
-        mockedProblemsService.Setup(_ => _.GetAsync(It.IsAny<string>(), default)).ReturnsAsync(problem);
+        mockedProblemsService.Setup(_ => _.GetAsync(It.Is(problem!.Id, new StringEqualityComparer())!, default)).ReturnsAsync(problem);
 
         var mockedTestSetsService = new Mock<ITestSetsService>();
 
         var problemsController = new ProblemsController(mockedProblemsService.Object, mockedTestSetsService.Object);
 
         // Act
-        var actionResult = await problemsController.Put(problem!.Id!, updatedProblem, default);
+        var actionResult = await problemsController.Put(problem!.Id!, updatedProblem);
 
         // Assert
         Assert.NotNull(actionResult);
         Assert.IsType<NoContentResult>(actionResult);
 
-        mockedProblemsService.Verify(_ => _.UpdateAsync(It.Is<Problem>(c => validateProblem(c)), default), Times.Once);
+        mockedProblemsService.Verify(_ => _.UpdateAsync(It.Is(updatedProblem.ToEntity(), new ProblemEqualityComparer()), default), Times.Once);
     }
 
     [Fact]
@@ -414,7 +910,7 @@ public class ProblemsControllerTests
         var problemsController = new ProblemsController(mockedProblemsService.Object, mockedTestSetsService.Object);
 
         // Act
-        var actionResult = await problemsController.Put("64639f6fcdde06187b09ecae", new ProblemModel(), default);
+        var actionResult = await problemsController.Put("64639f6fcdde06187b09ecae", new ProblemModel());
 
         // Assert
         Assert.NotNull(actionResult);

--- a/src/Tsa.Submissions.Coding.UnitTests/WebApi/Controllers/ProblemsControllerTests.cs
+++ b/src/Tsa.Submissions.Coding.UnitTests/WebApi/Controllers/ProblemsControllerTests.cs
@@ -177,7 +177,9 @@ public class ProblemsControllerTests
         mockedProblemsService.Setup(_ => _.GetAsync(It.IsAny<string>(), default))
             .ReturnsAsync(problem);
 
-        var problemsController = new ProblemsController(mockedProblemsService.Object);
+        var mockedTestSetsService = new Mock<ITestSetsService>();
+
+        var problemsController = new ProblemsController(mockedProblemsService.Object, mockedTestSetsService.Object);
 
         // Act
         var actionResult = await problemsController.Delete("64639f6fcdde06187b09ecae", default);
@@ -194,7 +196,9 @@ public class ProblemsControllerTests
         // Arrange
         var mockedProblemsService = new Mock<IProblemsService>();
 
-        var problemsController = new ProblemsController(mockedProblemsService.Object);
+        var mockedTestSetsService = new Mock<ITestSetsService>();
+
+        var problemsController = new ProblemsController(mockedProblemsService.Object, mockedTestSetsService.Object);
 
         // Act
         var actionResult = await problemsController.Delete("64639f6fcdde06187b09ecae", default);
@@ -211,7 +215,9 @@ public class ProblemsControllerTests
         // Arrange
         var mockedProblemsService = new Mock<IProblemsService>();
 
-        var problemsController = new ProblemsController(mockedProblemsService.Object);
+        var mockedTestSetsService = new Mock<ITestSetsService>();
+
+        var problemsController = new ProblemsController(mockedProblemsService.Object, mockedTestSetsService.Object);
 
         // Act
         var actionResult = await problemsController.Get("64639f6fcdde06187b09ecae", default);
@@ -234,7 +240,9 @@ public class ProblemsControllerTests
         mockedProblemsService.Setup(_ => _.GetAsync(It.IsAny<string>(), default))
             .ReturnsAsync(problem);
 
-        var problemsController = new ProblemsController(mockedProblemsService.Object);
+        var mockedTestSetsService = new Mock<ITestSetsService>();
+
+        var problemsController = new ProblemsController(mockedProblemsService.Object, mockedTestSetsService.Object);
 
         // Act
         var actionResult = await problemsController.Get("64639f6fcdde06187b09ecae", default);
@@ -259,7 +267,9 @@ public class ProblemsControllerTests
         mockedProblemsService.Setup(_ => _.GetAsync(default))
             .ReturnsAsync(emptyProblemsList);
 
-        var problemsController = new ProblemsController(mockedProblemsService.Object);
+        var mockedTestSetsService = new Mock<ITestSetsService>();
+
+        var problemsController = new ProblemsController(mockedProblemsService.Object, mockedTestSetsService.Object);
 
         // Act
         var actionResult = await problemsController.Get(default);
@@ -287,7 +297,9 @@ public class ProblemsControllerTests
         mockedProblemsService.Setup(_ => _.GetAsync(default))
             .ReturnsAsync(problemsList);
 
-        var problemsController = new ProblemsController(mockedProblemsService.Object);
+        var mockedTestSetsService = new Mock<ITestSetsService>();
+
+        var problemsController = new ProblemsController(mockedProblemsService.Object, mockedTestSetsService.Object);
 
         // Act
         var actionResult = await problemsController.Get(default);
@@ -324,7 +336,9 @@ public class ProblemsControllerTests
 
         var mockedProblemsService = new Mock<IProblemsService>();
 
-        var problemsController = new ProblemsController(mockedProblemsService.Object);
+        var mockedTestSetsService = new Mock<ITestSetsService>();
+
+        var problemsController = new ProblemsController(mockedProblemsService.Object, mockedTestSetsService.Object);
 
         // Act
         var createdAtActionResult = await problemsController.Post(newProblem, default);
@@ -367,7 +381,9 @@ public class ProblemsControllerTests
         var mockedProblemsService = new Mock<IProblemsService>();
         mockedProblemsService.Setup(_ => _.GetAsync(It.IsAny<string>(), default)).ReturnsAsync(problem);
 
-        var problemsController = new ProblemsController(mockedProblemsService.Object);
+        var mockedTestSetsService = new Mock<ITestSetsService>();
+
+        var problemsController = new ProblemsController(mockedProblemsService.Object, mockedTestSetsService.Object);
 
         // Act
         var actionResult = await problemsController.Put(problem!.Id!, updatedProblem, default);
@@ -386,7 +402,9 @@ public class ProblemsControllerTests
         // Arrange
         var mockedProblemsService = new Mock<IProblemsService>();
 
-        var problemsController = new ProblemsController(mockedProblemsService.Object);
+        var mockedTestSetsService = new Mock<ITestSetsService>();
+
+        var problemsController = new ProblemsController(mockedProblemsService.Object, mockedTestSetsService.Object);
 
         // Act
         var actionResult = await problemsController.Put("64639f6fcdde06187b09ecae", new ProblemModel(), default);

--- a/src/Tsa.Submissions.Coding.UnitTests/WebApi/Controllers/ProblemsControllerTests.cs
+++ b/src/Tsa.Submissions.Coding.UnitTests/WebApi/Controllers/ProblemsControllerTests.cs
@@ -49,6 +49,10 @@ public class ProblemsControllerTests
                     Assert.Equal(SubmissionRoles.All, authorizeAttribute.Roles);
                     break;
 
+                case "GetTestSets":
+                    Assert.Equal(SubmissionRoles.All, authorizeAttribute.Roles);
+                    break;
+
                 case "Post":
                     Assert.Equal(SubmissionRoles.Judge, authorizeAttribute.Roles);
                     break;
@@ -87,6 +91,9 @@ public class ProblemsControllerTests
                     attributeType = typeof(HttpDeleteAttribute);
                     break;
                 case "get":
+                    attributeType = typeof(HttpGetAttribute);
+                    break;
+                case "gettestsets":
                     attributeType = typeof(HttpGetAttribute);
                     break;
                 case "head":

--- a/src/Tsa.Submissions.Coding.UnitTests/WebApi/Controllers/ProblemsControllerTests.cs
+++ b/src/Tsa.Submissions.Coding.UnitTests/WebApi/Controllers/ProblemsControllerTests.cs
@@ -227,7 +227,7 @@ public class ProblemsControllerTests
         var problemsController = new ProblemsController(mockedProblemsService.Object, mockedTestSetsService.Object);
 
         // Act
-        var actionResult = await problemsController.Get("64639f6fcdde06187b09ecae", default);
+        var actionResult = await problemsController.Get("64639f6fcdde06187b09ecae");
 
         // Assert
         Assert.NotNull(actionResult);
@@ -252,7 +252,7 @@ public class ProblemsControllerTests
         var problemsController = new ProblemsController(mockedProblemsService.Object, mockedTestSetsService.Object);
 
         // Act
-        var actionResult = await problemsController.Get("64639f6fcdde06187b09ecae", default);
+        var actionResult = await problemsController.Get("64639f6fcdde06187b09ecae");
 
         // Assert
         Assert.NotNull(actionResult);
@@ -279,7 +279,7 @@ public class ProblemsControllerTests
         var problemsController = new ProblemsController(mockedProblemsService.Object, mockedTestSetsService.Object);
 
         // Act
-        var actionResult = await problemsController.Get(default);
+        var actionResult = await problemsController.Get();
 
         // Assert
         Assert.NotNull(actionResult);
@@ -309,7 +309,7 @@ public class ProblemsControllerTests
         var problemsController = new ProblemsController(mockedProblemsService.Object, mockedTestSetsService.Object);
 
         // Act
-        var actionResult = await problemsController.Get(default);
+        var actionResult = await problemsController.Get();
 
         // Assert
         Assert.NotNull(actionResult);

--- a/src/Tsa.Submissions.Coding.UnitTests/WebApi/Controllers/StatusControllerTests.cs
+++ b/src/Tsa.Submissions.Coding.UnitTests/WebApi/Controllers/StatusControllerTests.cs
@@ -95,9 +95,13 @@ public class StatusControllerTests
 
     #region Inline Data
 
+    [InlineData(PingableServiceFailures.Problems | PingableServiceFailures.Teams | PingableServiceFailures.TestSets)]
     [InlineData(PingableServiceFailures.Problems | PingableServiceFailures.Teams)]
+    [InlineData(PingableServiceFailures.Problems | PingableServiceFailures.TestSets)]
+    [InlineData(PingableServiceFailures.Teams | PingableServiceFailures.TestSets)]
     [InlineData(PingableServiceFailures.Problems)]
     [InlineData(PingableServiceFailures.Teams)]
+    [InlineData(PingableServiceFailures.TestSets)]
 
     #endregion
 
@@ -133,9 +137,13 @@ public class StatusControllerTests
 
     #region Inline Data
 
+    [InlineData(PingableServiceFailures.Problems | PingableServiceFailures.Teams | PingableServiceFailures.TestSets)]
     [InlineData(PingableServiceFailures.Problems | PingableServiceFailures.Teams)]
+    [InlineData(PingableServiceFailures.Problems | PingableServiceFailures.TestSets)]
+    [InlineData(PingableServiceFailures.Teams | PingableServiceFailures.TestSets)]
     [InlineData(PingableServiceFailures.Problems)]
     [InlineData(PingableServiceFailures.Teams)]
+    [InlineData(PingableServiceFailures.TestSets)]
 
     #endregion
 
@@ -170,7 +178,7 @@ public class StatusControllerTests
 
     private static Type[] GetServiceTypes()
     {
-        return new[] { typeof(ProblemsService), typeof(TeamsService) };
+        return new[] { typeof(ProblemsService), typeof(TeamsService), typeof(TestSetsService) };
     }
 
     [Fact]
@@ -337,19 +345,20 @@ public class StatusControllerTests
         Assert.True(servicesStatus!.IsHealthy);
         Assert.True(servicesStatus.TeamsServiceIsAlive);
     }
+}
 
-    [Flags]
-    public enum PingableServiceFailures
-    {
-        None = 0,
-        Problems = 1,
-        Teams = 2
-    }
+[Flags]
+public enum PingableServiceFailures
+{
+    None = 0,
+    Problems = 1 << 0,
+    Teams = 1 << 1,
+    TestSets = 1 << 2
+}
 
-    public enum ServiceFailureType
-    {
-        None,
-        ExceptionThrown,
-        PingFailed
-    }
+public enum ServiceFailureType
+{
+    None,
+    ExceptionThrown,
+    PingFailed
 }

--- a/src/Tsa.Submissions.Coding.UnitTests/WebApi/Controllers/TestSetsControllerTests.cs
+++ b/src/Tsa.Submissions.Coding.UnitTests/WebApi/Controllers/TestSetsControllerTests.cs
@@ -1,0 +1,776 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Reflection;
+using System.Security.Claims;
+using System.Security.Principal;
+using System.Threading;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Tsa.Submissions.Coding.UnitTests.Data;
+using Tsa.Submissions.Coding.UnitTests.Helpers;
+using Tsa.Submissions.Coding.WebApi.Authorization;
+using Tsa.Submissions.Coding.WebApi.Controllers;
+using Tsa.Submissions.Coding.WebApi.Entities;
+using Tsa.Submissions.Coding.WebApi.Exceptions;
+using Tsa.Submissions.Coding.WebApi.Models;
+using Tsa.Submissions.Coding.WebApi.Services;
+using Xunit;
+
+namespace Tsa.Submissions.Coding.UnitTests.WebApi.Controllers;
+
+[ExcludeFromCodeCoverage]
+public class TestSetsControllerTests
+{
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public void Controller_Public_Methods_Should_Have_Authorize_Attribute_With_Proper_Roles()
+    {
+        var testSetsController = typeof(TestSetsController);
+
+        var methodInfos = testSetsController.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly);
+
+        Assert.NotEmpty(methodInfos);
+
+        foreach (var methodInfo in methodInfos)
+        {
+            var attributes = methodInfo.GetCustomAttributes(typeof(AuthorizeAttribute), false);
+
+            Assert.NotNull(attributes);
+            Assert.NotEmpty(attributes);
+            Assert.Single(attributes);
+
+            var authorizeAttribute = (AuthorizeAttribute)attributes[0];
+
+            switch (methodInfo.Name)
+            {
+                case "Delete":
+                    Assert.Equal(SubmissionRoles.Judge, authorizeAttribute.Roles);
+                    break;
+
+                case "Get":
+                    Assert.Equal(SubmissionRoles.All, authorizeAttribute.Roles);
+                    break;
+
+                case "GetTestSets":
+                    Assert.Equal(SubmissionRoles.All, authorizeAttribute.Roles);
+                    break;
+
+                case "Post":
+                    Assert.Equal(SubmissionRoles.Judge, authorizeAttribute.Roles);
+                    break;
+
+                case "Put":
+                    Assert.Equal(SubmissionRoles.Judge, authorizeAttribute.Roles);
+                    break;
+
+                default:
+                    Assert.Fail($"A test case for the method `{methodInfo.Name}` does not exist");
+                    break;
+            }
+        }
+    }
+
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public void Controller_Public_Methods_Should_Have_Http_Method_Attribute()
+    {
+        var testSetsController = typeof(TestSetsController);
+
+        var methodInfos = testSetsController.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly);
+
+        Assert.NotEmpty(methodInfos);
+
+        foreach (var methodInfo in methodInfos)
+        {
+            // Needs to be nullable so the compiler sees it's initialized
+            // The Assert.Fail doesn't tell it that the line it's being used
+            // will only ever be hit if it's initialized
+            Type? attributeType = null;
+
+            switch (methodInfo.Name.ToLower())
+            {
+                case "delete":
+                    attributeType = typeof(HttpDeleteAttribute);
+                    break;
+                case "get":
+                    attributeType = typeof(HttpGetAttribute);
+                    break;
+                case "gettestsets":
+                    attributeType = typeof(HttpGetAttribute);
+                    break;
+                case "head":
+                    attributeType = typeof(HttpHeadAttribute);
+                    break;
+                case "options":
+                    attributeType = typeof(HttpOptionsAttribute);
+                    break;
+                case "patch":
+                    attributeType = typeof(HttpPatchAttribute);
+                    break;
+                case "post":
+                    attributeType = typeof(HttpPostAttribute);
+                    break;
+                case "put":
+                    attributeType = typeof(HttpPutAttribute);
+                    break;
+                default:
+                    Assert.Fail("Unsupported public HTTP operation");
+                    break;
+            }
+
+            var attributes = methodInfo.GetCustomAttributes(attributeType, false);
+
+            Assert.NotNull(attributes);
+            Assert.NotEmpty(attributes);
+            Assert.Single(attributes);
+        }
+    }
+
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public void Controller_Should_Have_ApiController_Attribute()
+    {
+        var testSetsController = typeof(TestSetsController);
+
+        var attributes = testSetsController.GetCustomAttributes(typeof(ApiControllerAttribute), false);
+
+        Assert.NotNull(attributes);
+        Assert.NotEmpty(attributes);
+        Assert.Single(attributes);
+    }
+
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public void Controller_Should_Have_Produces_Attribute()
+    {
+        var testSetsController = typeof(TestSetsController);
+
+        var attributes = testSetsController.GetCustomAttributes(typeof(ProducesAttribute), false);
+
+        Assert.NotNull(attributes);
+        Assert.NotEmpty(attributes);
+        Assert.Single(attributes);
+
+        var producesAttribute = (ProducesAttribute)attributes[0];
+
+        Assert.Contains("application/json", producesAttribute.ContentTypes);
+    }
+
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public void Controller_Should_Have_Route_Attribute()
+    {
+        var testSetsController = typeof(TestSetsController);
+
+        var attributes = testSetsController.GetCustomAttributes(typeof(RouteAttribute), false);
+
+        Assert.NotNull(attributes);
+        Assert.NotEmpty(attributes);
+        Assert.Single(attributes);
+
+        var routeAttribute = (RouteAttribute)attributes[0];
+
+        Assert.Equal("api/[controller]", routeAttribute.Template);
+    }
+
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public async void Delete_Should_Return_No_Content()
+    {
+        // Arrange
+        var testSetsTestData = new TestSetsTestData();
+
+        var testSet = testSetsTestData.First(_ => (TestSetDataIssues)_[1] == TestSetDataIssues.None)[0] as TestSet;
+
+        var mockedProblemsService = new Mock<IProblemsService>();
+
+        var mockedTestSetsService = new Mock<ITestSetsService>();
+        mockedTestSetsService
+            .Setup(_ => _.GetAsync(It.IsAny<string>(), default))
+            .ReturnsAsync(testSet);
+
+        var problemsController = new TestSetsController(mockedProblemsService.Object, mockedTestSetsService.Object);
+
+        // Act
+        var actionResult = await problemsController.Delete("64639f6fcdde06187b09ecae");
+
+        // Assert
+        Assert.NotNull(actionResult);
+        Assert.IsType<NoContentResult>(actionResult);
+    }
+
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public async void Delete_Should_Return_Not_Found()
+    {
+        // Arrange
+        var mockedProblemsService = new Mock<IProblemsService>();
+
+        var mockedTestSetsService = new Mock<ITestSetsService>();
+
+        var problemsController = new TestSetsController(mockedProblemsService.Object, mockedTestSetsService.Object);
+
+        // Act
+        var actionResult = await problemsController.Delete("64639f6fcdde06187b09ecae");
+
+        // Assert
+        Assert.NotNull(actionResult);
+        Assert.IsType<NotFoundResult>(actionResult);
+    }
+
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public async void Get_By_Id_Should_Return_Not_Found()
+    {
+        // Arrange
+        var mockedProblemsService = new Mock<IProblemsService>();
+
+        var mockedTestSetsService = new Mock<ITestSetsService>();
+
+        var problemsController = new TestSetsController(mockedProblemsService.Object, mockedTestSetsService.Object);
+
+        // Act
+        var actionResult = await problemsController.Get("64639f6fcdde06187b09ecae");
+
+        // Assert
+        Assert.NotNull(actionResult);
+        Assert.IsType<NotFoundResult>(actionResult.Result);
+    }
+
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public async void Get_By_Id_Should_Return_Not_Found_For_Participant_When_Not_Is_Public()
+    {
+        // Arrange
+        var testSetsTestData = new TestSetsTestData();
+
+        var testSet = testSetsTestData.First(_ =>
+            !((TestSet)_[0]).IsPublic &&
+            (TestSetDataIssues)_[1] == TestSetDataIssues.None)[0] as TestSet;
+
+        var mockedProblemsService = new Mock<IProblemsService>();
+
+        var mockedTestSetsService = new Mock<ITestSetsService>();
+        mockedTestSetsService.Setup(_ => _.GetAsync(It.IsAny<string>(), default))
+            .ReturnsAsync(testSet);
+
+        var identityMock = new Mock<IIdentity>();
+        identityMock.Setup(i => i.Name).Returns("0000-000");
+
+        var claimsPrincipalMock = new Mock<ClaimsPrincipal>();
+        claimsPrincipalMock.Setup(cp => cp.Identity).Returns(identityMock.Object);
+        claimsPrincipalMock.Setup(cp => cp.IsInRole(It.IsAny<string>())).Returns(true);
+
+        var httpContext = new DefaultHttpContext
+        {
+            User = claimsPrincipalMock.Object
+        };
+
+        var problemsController = new TestSetsController(mockedProblemsService.Object, mockedTestSetsService.Object)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext
+            }
+        };
+
+        // Act
+        var actionResult = await problemsController.Get("64639f6fcdde06187b09ecae");
+
+        // Assert
+        Assert.NotNull(actionResult.Result as NotFoundResult);
+    }
+
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public async void Get_By_Id_Should_Return_Ok_For_Judge()
+    {
+        // Arrange
+        var testSetsTestData = new TestSetsTestData();
+
+        var testSet = testSetsTestData.First(_ => (TestSetDataIssues)_[1] == TestSetDataIssues.None)[0] as TestSet;
+
+        var mockedProblemsService = new Mock<IProblemsService>();
+
+        var mockedTestSetsService = new Mock<ITestSetsService>();
+        mockedTestSetsService.Setup(_ => _.GetAsync(It.IsAny<string>(), default))
+            .ReturnsAsync(testSet);
+
+        var identityMock = new Mock<IIdentity>();
+        identityMock.Setup(i => i.Name).Returns("0000-000");
+
+        var claimsPrincipalMock = new Mock<ClaimsPrincipal>();
+        claimsPrincipalMock.Setup(cp => cp.Identity).Returns(identityMock.Object);
+        claimsPrincipalMock.Setup(cp => cp.IsInRole(It.IsAny<string>())).Returns(false);
+
+        var httpContext = new DefaultHttpContext
+        {
+            User = claimsPrincipalMock.Object
+        };
+
+        var problemsController = new TestSetsController(mockedProblemsService.Object, mockedTestSetsService.Object)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext
+            }
+        };
+
+        // Act
+        var actionResult = await problemsController.Get("64639f6fcdde06187b09ecae");
+
+        // Assert
+        Assert.NotNull(actionResult);
+        Assert.NotNull(actionResult.Value);
+
+        var testSetModel = actionResult.Value;
+
+        Assert.Equal(testSet!.Id, testSetModel.Id);
+        Assert.Equal(testSet.Inputs?.Count, testSetModel.Inputs?.Count);
+        Assert.Equal(testSet.IsPublic, testSetModel.IsPublic);
+        Assert.Equal(testSet.Name, testSetModel.Name);
+        Assert.Equal(testSet.Problem?.Id.AsString, testSetModel.ProblemId);
+    }
+
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public async void Get_By_Id_Should_Return_Ok_For_Participant_When_Is_Public()
+    {
+        // Arrange
+        var testSetsTestData = new TestSetsTestData();
+
+        var testSet = testSetsTestData.First(_ =>
+            ((TestSet)_[0]).IsPublic &&
+            (TestSetDataIssues)_[1] == TestSetDataIssues.None)[0] as TestSet;
+
+        var mockedProblemsService = new Mock<IProblemsService>();
+
+        var mockedTestSetsService = new Mock<ITestSetsService>();
+        mockedTestSetsService.Setup(_ => _.GetAsync(It.IsAny<string>(), default))
+            .ReturnsAsync(testSet);
+
+        var identityMock = new Mock<IIdentity>();
+        identityMock.Setup(i => i.Name).Returns("0000-000");
+
+        var claimsPrincipalMock = new Mock<ClaimsPrincipal>();
+        claimsPrincipalMock.Setup(cp => cp.Identity).Returns(identityMock.Object);
+        claimsPrincipalMock.Setup(cp => cp.IsInRole(It.IsAny<string>())).Returns(true);
+
+        var httpContext = new DefaultHttpContext
+        {
+            User = claimsPrincipalMock.Object
+        };
+
+        var problemsController = new TestSetsController(mockedProblemsService.Object, mockedTestSetsService.Object)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext
+            }
+        };
+
+        // Act
+        var actionResult = await problemsController.Get("64639f6fcdde06187b09ecae");
+
+        // Assert
+        Assert.NotNull(actionResult);
+        Assert.NotNull(actionResult.Value);
+
+        var testSetModel = actionResult.Value;
+
+        Assert.Equal(testSet!.Id, testSetModel.Id);
+        Assert.Equal(testSet.Inputs?.Count, testSetModel.Inputs?.Count);
+        Assert.Equal(testSet.IsPublic, testSetModel.IsPublic);
+        Assert.Equal(testSet.Name, testSetModel.Name);
+        Assert.Equal(testSet.Problem?.Id.AsString, testSetModel.ProblemId);
+    }
+
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public async void Get_Should_Return_Ok_When_Empty_For_Judge()
+    {
+        // Arrange
+        var emptyTestSetList = new List<TestSet>();
+
+        var mockedProblemsService = new Mock<IProblemsService>();
+
+        var mockedTestSetsService = new Mock<ITestSetsService>();
+        mockedTestSetsService.Setup(_ => _.GetAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(emptyTestSetList);
+
+        var identityMock = new Mock<IIdentity>();
+        identityMock.Setup(i => i.Name).Returns("0000-000");
+
+        var claimsPrincipalMock = new Mock<ClaimsPrincipal>();
+        claimsPrincipalMock.Setup(cp => cp.Identity).Returns(identityMock.Object);
+        claimsPrincipalMock.Setup(cp => cp.IsInRole(It.IsAny<string>())).Returns(false);
+
+        var httpContext = new DefaultHttpContext
+        {
+            User = claimsPrincipalMock.Object
+        };
+
+        var problemsController = new TestSetsController(mockedProblemsService.Object, mockedTestSetsService.Object)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext
+            }
+        };
+
+        // Act
+        var actionResult = await problemsController.Get();
+
+        // Assert
+        Assert.NotNull(actionResult);
+        Assert.NotNull(actionResult.Value);
+        Assert.Empty(actionResult.Value!);
+    }
+
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public async void Get_Should_Return_Ok_When_Empty_For_Participant()
+    {
+        // Arrange
+        var emptyTestSetList = new List<TestSet>();
+
+        var mockedProblemsService = new Mock<IProblemsService>();
+
+        var mockedTestSetsService = new Mock<ITestSetsService>();
+        mockedTestSetsService.Setup(_ => _.GetAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(emptyTestSetList);
+
+        var identityMock = new Mock<IIdentity>();
+        identityMock.Setup(i => i.Name).Returns("0000-000");
+
+        var claimsPrincipalMock = new Mock<ClaimsPrincipal>();
+        claimsPrincipalMock.Setup(cp => cp.Identity).Returns(identityMock.Object);
+        claimsPrincipalMock.Setup(cp => cp.IsInRole(It.IsAny<string>())).Returns(true);
+
+        var httpContext = new DefaultHttpContext
+        {
+            User = claimsPrincipalMock.Object
+        };
+
+        var problemsController = new TestSetsController(mockedProblemsService.Object, mockedTestSetsService.Object)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext
+            }
+        };
+
+        // Act
+        var actionResult = await problemsController.Get();
+
+        // Assert
+        Assert.NotNull(actionResult);
+        Assert.NotNull(actionResult.Value);
+        Assert.Empty(actionResult.Value!);
+    }
+
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public async void Get_Should_Return_Ok_When_Not_Empty_For_Judge()
+    {
+        // Arrange
+        var testSetsTestData = new TestSetsTestData();
+
+        var testSetList = testSetsTestData
+            .Where(_ => (TestSetDataIssues)_[1] == TestSetDataIssues.None)
+            .Select(_ => _[0])
+            .Cast<TestSet>()
+            .ToList();
+
+        var mockedProblemsService = new Mock<IProblemsService>();
+
+        var mockedTestSetsService = new Mock<ITestSetsService>();
+        mockedTestSetsService.Setup(_ => _.GetAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(testSetList);
+
+        var identityMock = new Mock<IIdentity>();
+        identityMock.Setup(i => i.Name).Returns("0000-000");
+
+        var claimsPrincipalMock = new Mock<ClaimsPrincipal>();
+        claimsPrincipalMock.Setup(cp => cp.Identity).Returns(identityMock.Object);
+        claimsPrincipalMock.Setup(cp => cp.IsInRole(It.IsAny<string>())).Returns(false);
+
+        var httpContext = new DefaultHttpContext
+        {
+            User = claimsPrincipalMock.Object
+        };
+
+        var problemsController = new TestSetsController(mockedProblemsService.Object, mockedTestSetsService.Object)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext
+            }
+        };
+
+        // Act
+        var actionResult = await problemsController.Get();
+
+        // Assert
+        Assert.NotNull(actionResult);
+        Assert.NotNull(actionResult.Value);
+        Assert.NotEmpty(actionResult.Value!);
+        Assert.Equal(testSetList.Count, actionResult.Value!.Count);
+    }
+
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public async void Get_Should_Return_Ok_When_Not_Empty_For_Participant()
+    {
+        // Arrange
+        var testSetsTestData = new TestSetsTestData();
+
+        var testSetList = testSetsTestData
+            .Where(_ => (TestSetDataIssues)_[1] == TestSetDataIssues.None)
+            .Select(_ => _[0])
+            .Cast<TestSet>()
+            .ToList();
+
+        var mockedProblemsService = new Mock<IProblemsService>();
+
+        var mockedTestSetsService = new Mock<ITestSetsService>();
+        mockedTestSetsService.Setup(_ => _.GetAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(testSetList);
+
+        var identityMock = new Mock<IIdentity>();
+        identityMock.Setup(i => i.Name).Returns("0000-000");
+
+        var claimsPrincipalMock = new Mock<ClaimsPrincipal>();
+        claimsPrincipalMock.Setup(cp => cp.Identity).Returns(identityMock.Object);
+        claimsPrincipalMock.Setup(cp => cp.IsInRole(It.IsAny<string>())).Returns(true);
+
+        var httpContext = new DefaultHttpContext
+        {
+            User = claimsPrincipalMock.Object
+        };
+
+        var problemsController = new TestSetsController(mockedProblemsService.Object, mockedTestSetsService.Object)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext
+            }
+        };
+
+        // Act
+        var actionResult = await problemsController.Get();
+
+        // Assert
+        Assert.NotNull(actionResult);
+        Assert.NotNull(actionResult.Value);
+        Assert.NotEmpty(actionResult.Value!);
+        Assert.Equal(testSetList.Count(_ => _.IsPublic), actionResult.Value!.Count);
+    }
+
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public async void Post_Should_Return_Created()
+    {
+        // Arrange
+        var newTestSet = new TestSetModel
+        {
+            Id = "000000000000000000000001",
+            Inputs = new List<TestSetInputModel>
+            {
+                new()
+                {
+                    IsArray = false,
+                    DataType = "string",
+                    Index = 0,
+                    ValueAsJson = "{ \"value\": \"string a\" }"
+                }
+            },
+            IsPublic = true,
+            Name = "Test Set #1",
+            ProblemId = "000000000000000000000001"
+        };
+
+        Func<TestSet, bool> validateTestSet = testSetToValidate =>
+        {
+            var idsMatch = testSetToValidate.Id == newTestSet.Id;
+            var isPublicMatch = testSetToValidate.IsPublic == newTestSet.IsPublic;
+            var namesMatch = testSetToValidate.Name == newTestSet.Name;
+            var problemsMatch = testSetToValidate.Problem?.Id.AsString == newTestSet.ProblemId;
+
+            var inputsMatch = testSetToValidate.Inputs is { Count: 1 } &&
+                              testSetToValidate.Inputs[0].IsArray == newTestSet.Inputs[0].IsArray &&
+                              testSetToValidate.Inputs[0].DataType == newTestSet.Inputs[0].DataType &&
+                              testSetToValidate.Inputs[0].Index == newTestSet.Inputs[0].Index &&
+                              testSetToValidate.Inputs[0].ValueAsJson == newTestSet.Inputs[0].ValueAsJson;
+
+
+            return idsMatch && isPublicMatch && namesMatch && problemsMatch && inputsMatch;
+        };
+
+        var mockedProblemsService = new Mock<IProblemsService>();
+        mockedProblemsService
+            .Setup(_ => _.ExistsAsync(It.Is(newTestSet.ProblemId, new StringEqualityComparer()), default))
+            .ReturnsAsync(true);
+
+        var mockedTestSetsService = new Mock<ITestSetsService>();
+
+        var problemsController = new TestSetsController(mockedProblemsService.Object, mockedTestSetsService.Object);
+
+        // Act
+        var createdAtActionResult = await problemsController.Post(newTestSet);
+
+        // Assert
+        Assert.NotNull(createdAtActionResult);
+
+        Assert.IsType<TestSetModel>(createdAtActionResult.Value);
+
+        mockedTestSetsService.Verify(_ => _.CreateAsync(It.Is<TestSet>(testSet => validateTestSet(testSet)), default), Times.Once);
+    }
+
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public async void Post_Should_Throw_Exception_When_Problem_Is_Not_Found()
+    {
+        // Arrange
+        var newTestSet = new TestSetModel
+        {
+            Id = "000000000000000000000001",
+            Inputs = new List<TestSetInputModel>
+            {
+                new()
+                {
+                    IsArray = false,
+                    DataType = "string",
+                    Index = 0,
+                    ValueAsJson = "{ \"value\": \"string a\" }"
+                }
+            },
+            IsPublic = true,
+            Name = "Test Set #1",
+            ProblemId = "000000000000000000000001"
+        };
+
+        var mockedProblemsService = new Mock<IProblemsService>();
+        mockedProblemsService
+            .Setup(_ => _.ExistsAsync(It.Is(newTestSet.ProblemId, new StringEqualityComparer()), default))
+            .ReturnsAsync(false);
+
+        var mockedTestSetsService = new Mock<ITestSetsService>();
+
+        var problemsController = new TestSetsController(mockedProblemsService.Object, mockedTestSetsService.Object);
+
+        // Act and Assert
+        await Assert.ThrowsAsync<RequiredEntityNotFoundException>(() => problemsController.Post(newTestSet));
+    }
+
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public async void Put_Should_Return_No_Content()
+    {
+        // Arrange
+        var testSetsTestData = new TestSetsTestData();
+
+        var testSet = testSetsTestData.First(_ => (TestSetDataIssues)_[1] == TestSetDataIssues.None)[0] as TestSet;
+
+        var testSetModel = testSet!.ToModel();
+
+        Func<TestSet, bool> validateTestSet = testSetToValidate =>
+        {
+            var idsMatch = testSetToValidate.Id == testSet!.Id;
+            var isPublicMatch = testSetToValidate.IsPublic == testSet.IsPublic;
+            var namesMatch = testSetToValidate.Name == testSet.Name;
+            var problemsMatch = testSetToValidate.Problem?.Id.AsString == testSet.Problem?.Id.AsString;
+
+            var inputsMatch = true;
+
+            if (testSetToValidate.Inputs?.Count != testSet.Inputs?.Count) return false;
+
+            foreach (var testSetInput in testSet.Inputs!)
+            {
+                var testSetInputModel = testSetToValidate.Inputs!.SingleOrDefault(_ => _.Index == testSetInput.Index);
+
+                if (testSetInputModel == null) return false;
+
+                inputsMatch = testSetInputModel.IsArray == testSetInput.IsArray &&
+                              testSetInputModel.DataType == testSetInput.DataType &&
+                              testSetInputModel.Index == testSetInput.Index &&
+                              testSetInputModel.ValueAsJson == testSetInput.ValueAsJson;
+            }
+
+            return idsMatch && isPublicMatch && namesMatch && problemsMatch && inputsMatch;
+        };
+
+        var mockedProblemsService = new Mock<IProblemsService>();
+        mockedProblemsService
+            .Setup(_ => _.ExistsAsync(It.Is(testSetModel.ProblemId, new StringEqualityComparer())!, default))
+            .ReturnsAsync(true);
+
+        var mockedTestSetsService = new Mock<ITestSetsService>();
+        mockedTestSetsService
+            .Setup(_ => _.GetAsync(It.Is(testSet!.Id!, new StringEqualityComparer()), default))
+            .ReturnsAsync(testSet);
+
+        var problemsController = new TestSetsController(mockedProblemsService.Object, mockedTestSetsService.Object);
+
+        // Act
+        var actionResult = await problemsController.Put(testSet!.Id!, testSetModel);
+
+        // Assert
+        Assert.NotNull(actionResult);
+        Assert.IsType<NoContentResult>(actionResult);
+
+        mockedTestSetsService.Verify(_ => _.UpdateAsync(It.Is<TestSet>(testSetToValidate => validateTestSet(testSetToValidate)), default), Times.Once);
+    }
+
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public async void Put_Should_Return_Not_Found()
+    {
+        // Arrange
+        var problemId = Guid.NewGuid().ToString();
+
+        var mockedProblemsService = new Mock<IProblemsService>();
+        mockedProblemsService
+            .Setup(_ => _.ExistsAsync(It.Is(problemId, new StringEqualityComparer())!, default))
+            .ReturnsAsync(true);
+
+        var mockedTestSetsService = new Mock<ITestSetsService>();
+
+        var problemsController = new TestSetsController(mockedProblemsService.Object, mockedTestSetsService.Object);
+
+        // Act
+        var actionResult = await problemsController.Put("64639f6fcdde06187b09ecae", new TestSetModel { ProblemId = problemId });
+
+        // Assert
+        Assert.NotNull(actionResult);
+        Assert.IsType<NotFoundResult>(actionResult);
+    }
+
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public async void Put_Should_Throw_Exception_When_Problem_Is_Not_Found()
+    {
+        // Arrange
+        var testSetsTestData = new TestSetsTestData();
+
+        var testSet = testSetsTestData.First(_ => (TestSetDataIssues)_[1] == TestSetDataIssues.None)[0] as TestSet;
+
+        var testSetModel = testSet!.ToModel();
+
+        var mockedProblemsService = new Mock<IProblemsService>();
+        mockedProblemsService
+            .Setup(_ => _.ExistsAsync(It.Is(testSetModel.ProblemId, new StringEqualityComparer())!, default))
+            .ReturnsAsync(false);
+
+        var mockedTestSetsService = new Mock<ITestSetsService>();
+
+        var problemsController = new TestSetsController(mockedProblemsService.Object, mockedTestSetsService.Object);
+
+        // Act and Assert
+        await Assert.ThrowsAsync<RequiredEntityNotFoundException>(() => problemsController.Put(testSet!.Id!, testSetModel));
+    }
+}

--- a/src/Tsa.Submissions.Coding.UnitTests/WebApi/Entities/EntityExtensionsTests.cs
+++ b/src/Tsa.Submissions.Coding.UnitTests/WebApi/Entities/EntityExtensionsTests.cs
@@ -151,6 +151,61 @@ public class EntityExtensions
 
     [Fact]
     [Trait("TestCategory", "UnitTest")]
+    public void ToModel_For_TestSet_Should_Return_TestSetModel_With_ProblemId_Null_When_Problem_Is_Null()
+    {
+        // Arrange
+        var testSet = new TestSet
+        {
+            Id = "This is an ID",
+            Inputs = new List<TestSetInput>
+            {
+                new()
+                {
+                    DataType = "Data Type #1",
+                    Index = 1,
+                    Value = "Value #1"
+                },
+                new()
+                {
+                    DataType = "Data Type #2",
+                    Index = 2,
+                    Value = "Value #2"
+                },
+                new()
+                {
+                    DataType = "Data Type #3",
+                    Index = 3,
+                    Value = "Value #3"
+                }
+            },
+            IsPublic = true,
+            Name = "Test Set #1",
+            Problem = null
+        };
+
+        // Act
+        var testSetModel = testSet.ToModel();
+
+        // Assert
+        Assert.Equal(testSet.Id, testSetModel.Id);
+        Assert.NotNull(testSetModel.Inputs);
+        Assert.NotEmpty(testSetModel.Inputs);
+
+        foreach (var testSetInput in testSet.Inputs)
+        {
+            var testSetInputModel = testSetModel.Inputs.SingleOrDefault(_ => _.Index == testSetInput.Index);
+
+            Assert.NotNull(testSetInputModel);
+            Assert.Equal(testSetInput.DataType, testSetInputModel.DataType);
+            Assert.Equal(testSetInput.Value, testSetInputModel.Value);
+        }
+
+        Assert.Equal(testSet.Name, testSetModel.Name);
+        Assert.Null(testSetModel.ProblemId);
+    }
+
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
     public void ToModel_For_TestSetInput_Should_Return_TestSetInputModel()
     {
         // Arrange
@@ -168,5 +223,19 @@ public class EntityExtensions
         Assert.Equal(testSetInput.DataType, testSetInputModel.DataType);
         Assert.Equal(testSetInput.Index, testSetInputModel.Index);
         Assert.Equal(testSetInput.Value, testSetInputModel.Value);
+    }
+
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public void ToModels_For_TestSetInputs_Should_Return_Null_When_Inputs_Is_Null()
+    {
+        // Arrange
+        var testSet = new TestSet();
+
+        // Act
+        var testSetInputModels = testSet.Inputs.ToModels();
+
+        // Assert
+        Assert.Null(testSetInputModels);
     }
 }

--- a/src/Tsa.Submissions.Coding.UnitTests/WebApi/Entities/EntityExtensionsTests.cs
+++ b/src/Tsa.Submissions.Coding.UnitTests/WebApi/Entities/EntityExtensionsTests.cs
@@ -108,19 +108,22 @@ public class EntityExtensions
                 {
                     DataType = "Data Type #1",
                     Index = 1,
-                    Value = "Value #1"
+                    IsArray = true,
+                    ValueAsJson = "ValueAsJson #1"
                 },
                 new()
                 {
                     DataType = "Data Type #2",
                     Index = 2,
-                    Value = "Value #2"
+                    IsArray = false,
+                    ValueAsJson = "ValueAsJson #2"
                 },
                 new()
                 {
                     DataType = "Data Type #3",
                     Index = 3,
-                    Value = "Value #3"
+                    IsArray = true,
+                    ValueAsJson = "ValueAsJson #3"
                 }
             },
             IsPublic = true,
@@ -142,7 +145,8 @@ public class EntityExtensions
 
             Assert.NotNull(testSetInputModel);
             Assert.Equal(testSetInput.DataType, testSetInputModel.DataType);
-            Assert.Equal(testSetInput.Value, testSetInputModel.Value);
+            Assert.Equal(testSetInput.IsArray, testSetInputModel.IsArray);
+            Assert.Equal(testSetInput.ValueAsJson, testSetInputModel.ValueAsJson);
         }
 
         Assert.Equal(testSet.Name, testSetModel.Name);
@@ -163,19 +167,19 @@ public class EntityExtensions
                 {
                     DataType = "Data Type #1",
                     Index = 1,
-                    Value = "Value #1"
+                    ValueAsJson = "ValueAsJson #1"
                 },
                 new()
                 {
                     DataType = "Data Type #2",
                     Index = 2,
-                    Value = "Value #2"
+                    ValueAsJson = "ValueAsJson #2"
                 },
                 new()
                 {
                     DataType = "Data Type #3",
                     Index = 3,
-                    Value = "Value #3"
+                    ValueAsJson = "ValueAsJson #3"
                 }
             },
             IsPublic = true,
@@ -197,7 +201,7 @@ public class EntityExtensions
 
             Assert.NotNull(testSetInputModel);
             Assert.Equal(testSetInput.DataType, testSetInputModel.DataType);
-            Assert.Equal(testSetInput.Value, testSetInputModel.Value);
+            Assert.Equal(testSetInput.ValueAsJson, testSetInputModel.ValueAsJson);
         }
 
         Assert.Equal(testSet.Name, testSetModel.Name);
@@ -213,7 +217,8 @@ public class EntityExtensions
         {
             DataType = "Data Type",
             Index = 9999,
-            Value = "Value"
+            IsArray = true,
+            ValueAsJson = "ValueAsJson"
         };
 
         // Act
@@ -222,7 +227,8 @@ public class EntityExtensions
         // Assert
         Assert.Equal(testSetInput.DataType, testSetInputModel.DataType);
         Assert.Equal(testSetInput.Index, testSetInputModel.Index);
-        Assert.Equal(testSetInput.Value, testSetInputModel.Value);
+        Assert.Equal(testSetInput.IsArray, testSetInputModel.IsArray);
+        Assert.Equal(testSetInput.ValueAsJson, testSetInputModel.ValueAsJson);
     }
 
     [Fact]

--- a/src/Tsa.Submissions.Coding.UnitTests/WebApi/Entities/EntityExtensionsTests.cs
+++ b/src/Tsa.Submissions.Coding.UnitTests/WebApi/Entities/EntityExtensionsTests.cs
@@ -244,4 +244,104 @@ public class EntityExtensions
         // Assert
         Assert.Null(testSetInputModels);
     }
+
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public void ToModels_For_TestSets_Should_Return_TestSetModels()
+    {
+        // Arrange
+        var testSets = new List<TestSet>
+        {
+            new()
+            {
+                Id = "000000000000000000000000",
+                Inputs = new List<TestSetInput>
+                {
+                    new()
+                    {
+                        DataType = "Data Type #1",
+                        Index = 1,
+                        IsArray = true,
+                        ValueAsJson = "ValueAsJson #1"
+                    },
+                    new()
+                    {
+                        DataType = "Data Type #2",
+                        Index = 2,
+                        IsArray = false,
+                        ValueAsJson = "ValueAsJson #2"
+                    },
+                    new()
+                    {
+                        DataType = "Data Type #3",
+                        Index = 3,
+                        IsArray = true,
+                        ValueAsJson = "ValueAsJson #3"
+                    }
+                },
+                IsPublic = true,
+                Name = "Test Set #1",
+                Problem = new MongoDBRef(ProblemsService.MongoDbCollectionName, "000000000000000000000000")
+            },
+            new()
+            {
+                Id = "000000000000000000000001",
+                Inputs = new List<TestSetInput>
+                {
+                    new()
+                    {
+                        DataType = "Data Type #4",
+                        Index = 1,
+                        IsArray = true,
+                        ValueAsJson = "ValueAsJson #4"
+                    },
+                    new()
+                    {
+                        DataType = "Data Type #5",
+                        Index = 2,
+                        IsArray = false,
+                        ValueAsJson = "ValueAsJson #5"
+                    },
+                    new()
+                    {
+                        DataType = "Data Type #6",
+                        Index = 3,
+                        IsArray = true,
+                        ValueAsJson = "ValueAsJson #6"
+                    }
+                },
+                IsPublic = true,
+                Name = "Test Set #2",
+                Problem = new MongoDBRef(ProblemsService.MongoDbCollectionName, "000000000000000000000000")
+            }
+        };
+
+        // Act
+        var testSetModels = testSets.ToModels();
+
+        foreach (var testSetModel in testSetModels)
+        {
+            var testSet = testSets.SingleOrDefault(_ => _.Id == testSetModel.Id);
+
+            Assert.NotNull(testSet);
+
+            // Assert
+            Assert.Equal(testSet.Id, testSetModel.Id);
+            Assert.NotNull(testSetModel.Inputs);
+            Assert.NotEmpty(testSetModel.Inputs);
+
+            foreach (var testSetInput in testSet.Inputs!)
+            {
+                var testSetInputModel = testSetModel.Inputs.SingleOrDefault(_ => _.Index == testSetInput.Index);
+
+                Assert.NotNull(testSetInputModel);
+                Assert.Equal(testSetInput.DataType, testSetInputModel.DataType);
+                Assert.Equal(testSetInput.IsArray, testSetInputModel.IsArray);
+                Assert.Equal(testSetInput.ValueAsJson, testSetInputModel.ValueAsJson);
+            }
+
+            Assert.Equal(testSet.Name, testSetModel.Name);
+            Assert.Equal(testSet.Problem?.Id.AsString, testSetModel.ProblemId);
+        }
+    }
 }

--- a/src/Tsa.Submissions.Coding.UnitTests/WebApi/Entities/EntityExtensionsTests.cs
+++ b/src/Tsa.Submissions.Coding.UnitTests/WebApi/Entities/EntityExtensionsTests.cs
@@ -1,6 +1,9 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using MongoDB.Driver;
 using Tsa.Submissions.Coding.WebApi.Entities;
+using Tsa.Submissions.Coding.WebApi.Services;
 using Xunit;
 
 namespace Tsa.Submissions.Coding.UnitTests.WebApi.Entities;
@@ -89,5 +92,81 @@ public class EntityExtensions
         {
             Assert.Contains(team.Participants, _ => _.ParticipantId == teamModelParticipant.ParticipantId);
         }
+    }
+
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public void ToModel_For_TestSet_Should_Return_TestSetModel()
+    {
+        // Arrange
+        var testSet = new TestSet
+        {
+            Id = "This is an ID",
+            Inputs = new List<TestSetInput>
+            {
+                new()
+                {
+                    DataType = "Data Type #1",
+                    Index = 1,
+                    Value = "Value #1"
+                },
+                new()
+                {
+                    DataType = "Data Type #2",
+                    Index = 2,
+                    Value = "Value #2"
+                },
+                new()
+                {
+                    DataType = "Data Type #3",
+                    Index = 3,
+                    Value = "Value #3"
+                }
+            },
+            IsPublic = true,
+            Name = "Test Set #1",
+            Problem = new MongoDBRef(ProblemsService.MongoDbCollectionName, "000000000000000000000000")
+        };
+
+        // Act
+        var testSetModel = testSet.ToModel();
+
+        // Assert
+        Assert.Equal(testSet.Id, testSetModel.Id);
+        Assert.NotNull(testSetModel.Inputs);
+        Assert.NotEmpty(testSetModel.Inputs);
+
+        foreach (var testSetInput in testSet.Inputs)
+        {
+            var testSetInputModel = testSetModel.Inputs.SingleOrDefault(_ => _.Index == testSetInput.Index);
+
+            Assert.NotNull(testSetInputModel);
+            Assert.Equal(testSetInput.DataType, testSetInputModel.DataType);
+            Assert.Equal(testSetInput.Value, testSetInputModel.Value);
+        }
+
+        Assert.Equal(testSet.Name, testSetModel.Name);
+        Assert.Equal(testSet.Problem?.Id.AsString, testSetModel.ProblemId);
+    }
+
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public void ToModel_For_TestSetInput_Should_Return_TestSetInputModel()
+    {
+        // Arrange
+        var testSetInput = new TestSetInput
+        {
+            DataType = "Data Type",
+            Index = 9999,
+            Value = "Value"
+        };
+
+        // Act
+        var testSetInputModel = testSetInput.ToModel();
+
+        // Assert
+        Assert.Equal(testSetInput.DataType, testSetInputModel.DataType);
+        Assert.Equal(testSetInput.Index, testSetInputModel.Index);
+        Assert.Equal(testSetInput.Value, testSetInputModel.Value);
     }
 }

--- a/src/Tsa.Submissions.Coding.UnitTests/WebApi/Exceptions/RequiredEntityNotFoundExceptionTests.cs
+++ b/src/Tsa.Submissions.Coding.UnitTests/WebApi/Exceptions/RequiredEntityNotFoundExceptionTests.cs
@@ -1,0 +1,44 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Net;
+using Tsa.Submissions.Coding.WebApi.Exceptions;
+using Xunit;
+
+namespace Tsa.Submissions.Coding.UnitTests.WebApi.Exceptions;
+
+[ExcludeFromCodeCoverage]
+public class RequiredEntityNotFoundExceptionTests
+{
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public void Constructor_Should_Set_Attributes()
+    {
+        // Arrange
+        var entityName = "SampleEntity";
+
+        // Act
+        var requiredEntityNotFoundException = new RequiredEntityNotFoundException(entityName);
+
+        // Assert
+        Assert.Equal(entityName, requiredEntityNotFoundException.EntityName);
+        Assert.Equal(HttpStatusCode.NotFound, requiredEntityNotFoundException.HttpStatusCode);
+    }
+
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public void ToApiErrorResponseModel_Should_Return_ApiErrorResponseModel()
+    {
+        // Arrange
+        var errorCode = 2000;
+        var entityName = "SampleEntity";
+        var expectedMessage = $"Could not locate required resource for the `{entityName}` entity.";
+
+        var requiredEntityNotFoundException = new RequiredEntityNotFoundException(entityName);
+
+        // Act
+        var apiErrorResponseModel = requiredEntityNotFoundException.ToApiErrorResponseModel();
+
+        // Assert
+        Assert.Equal(errorCode, apiErrorResponseModel.ErrorCode);
+        Assert.Equal(expectedMessage, apiErrorResponseModel.Message);
+    }
+}

--- a/src/Tsa.Submissions.Coding.UnitTests/WebApi/Models/ModelExtensionsTests.cs
+++ b/src/Tsa.Submissions.Coding.UnitTests/WebApi/Models/ModelExtensionsTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using Tsa.Submissions.Coding.WebApi.Models;
 using Xunit;
 
@@ -29,6 +30,20 @@ public class ModelExtensions
         {
             Assert.Contains(participantModels, _ => _.ParticipantId == participant.ParticipantId);
         }
+    }
+
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public void ToEntities_For_TestSetInputModels_Should_Return_Null_When_Inputs_Is_Null()
+    {
+        // Arrange
+        var testSetModel = new TestSetModel();
+
+        // Act
+        var testSetInputs = testSetModel.Inputs.ToEntities();
+
+        // Assert
+        Assert.Null(testSetInputs);
     }
 
     [Fact]
@@ -112,5 +127,81 @@ public class ModelExtensions
         {
             Assert.Contains(teamModel.Participants, _ => _.ParticipantId == participant.ParticipantId);
         }
+    }
+
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public void ToEntity_For_TestSetInputModel_Should_Return_TestSetInput()
+    {
+        // Arrange
+        var testSetInputModel = new TestSetInputModel
+        {
+            DataType = "Data Type",
+            Index = 9999,
+            Value = "Value"
+        };
+
+        // Act
+        var testSetInput = testSetInputModel.ToEntity();
+
+        // Assert
+        Assert.Equal(testSetInputModel.DataType, testSetInput.DataType);
+        Assert.Equal(testSetInputModel.Index, testSetInput.Index);
+        Assert.Equal(testSetInputModel.Value, testSetInput.Value);
+    }
+
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public void ToEntity_For_TestSetModel_Should_Return_TestSet()
+    {
+        // Arrange
+        var testSetModel = new TestSetModel
+        {
+            Id = "This is an ID",
+            Inputs = new List<TestSetInputModel>
+            {
+                new()
+                {
+                    DataType = "Data Type #1",
+                    Index = 1,
+                    Value = "Value #1"
+                },
+                new()
+                {
+                    DataType = "Data Type #2",
+                    Index = 2,
+                    Value = "Value #2"
+                },
+                new()
+                {
+                    DataType = "Data Type #3",
+                    Index = 3,
+                    Value = "Value #3"
+                }
+            },
+            IsPublic = true,
+            Name = "Test Set #1",
+            ProblemId = "000000000000000000000000"
+        };
+
+        // Act
+        var testSet = testSetModel.ToEntity();
+
+        // Assert
+        Assert.Equal(testSetModel.Id, testSet.Id);
+        Assert.NotNull(testSet.Inputs);
+        Assert.NotEmpty(testSet.Inputs);
+
+        foreach (var testSetInputModel in testSetModel.Inputs)
+        {
+            var testSetInput = testSet.Inputs.SingleOrDefault(_ => _.Index == testSetInputModel.Index);
+
+            Assert.NotNull(testSetInput);
+            Assert.Equal(testSetInputModel.DataType, testSetInput.DataType);
+            Assert.Equal(testSetInputModel.Value, testSetInput.Value);
+        }
+
+        Assert.Equal(testSetModel.Name, testSet.Name);
+        Assert.Equal(testSetModel.ProblemId, testSet.Problem?.Id.AsString);
     }
 }

--- a/src/Tsa.Submissions.Coding.UnitTests/WebApi/Models/ModelExtensionsTests.cs
+++ b/src/Tsa.Submissions.Coding.UnitTests/WebApi/Models/ModelExtensionsTests.cs
@@ -138,7 +138,8 @@ public class ModelExtensions
         {
             DataType = "Data Type",
             Index = 9999,
-            Value = "Value"
+            IsArray = true,
+            ValueAsJson = "ValueAsJson"
         };
 
         // Act
@@ -147,7 +148,8 @@ public class ModelExtensions
         // Assert
         Assert.Equal(testSetInputModel.DataType, testSetInput.DataType);
         Assert.Equal(testSetInputModel.Index, testSetInput.Index);
-        Assert.Equal(testSetInputModel.Value, testSetInput.Value);
+        Assert.Equal(testSetInputModel.IsArray, testSetInput.IsArray);
+        Assert.Equal(testSetInputModel.ValueAsJson, testSetInput.ValueAsJson);
     }
 
     [Fact]
@@ -164,19 +166,22 @@ public class ModelExtensions
                 {
                     DataType = "Data Type #1",
                     Index = 1,
-                    Value = "Value #1"
+                    IsArray = true,
+                    ValueAsJson = "ValueAsJson #1"
                 },
                 new()
                 {
                     DataType = "Data Type #2",
                     Index = 2,
-                    Value = "Value #2"
+                    IsArray = false,
+                    ValueAsJson = "ValueAsJson #2"
                 },
                 new()
                 {
                     DataType = "Data Type #3",
                     Index = 3,
-                    Value = "Value #3"
+                    IsArray = true,
+                    ValueAsJson = "ValueAsJson #3"
                 }
             },
             IsPublic = true,
@@ -198,7 +203,8 @@ public class ModelExtensions
 
             Assert.NotNull(testSetInput);
             Assert.Equal(testSetInputModel.DataType, testSetInput.DataType);
-            Assert.Equal(testSetInputModel.Value, testSetInput.Value);
+            Assert.Equal(testSetInputModel.IsArray, testSetInput.IsArray);
+            Assert.Equal(testSetInputModel.ValueAsJson, testSetInput.ValueAsJson);
         }
 
         Assert.Equal(testSetModel.Name, testSet.Name);

--- a/src/Tsa.Submissions.Coding.UnitTests/WebApi/Models/ValueAsCharacterArrayModelTests.cs
+++ b/src/Tsa.Submissions.Coding.UnitTests/WebApi/Models/ValueAsCharacterArrayModelTests.cs
@@ -1,0 +1,27 @@
+using System.Diagnostics.CodeAnalysis;
+using Newtonsoft.Json;
+using Tsa.Submissions.Coding.WebApi.Models;
+using Xunit;
+
+namespace Tsa.Submissions.Coding.UnitTests.WebApi.Models;
+
+[ExcludeFromCodeCoverage]
+public class ValueAsCharacterArrayModelTests
+{
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public void TestSetInput_ValueAsJson_Is_Character_Array_Model_Should_Deserialize()
+    {
+        // Arrange
+        var json = "{ \"value\": [\"a\", \"b\", \"c\"] }";
+
+        var obj = JsonConvert.DeserializeObject<ValueAsCharacterArrayModel>(json);
+
+        Assert.NotNull(obj);
+        Assert.NotNull(obj.Value);
+        Assert.Equal(3, obj.Value.Length);
+        Assert.Equal('a', obj.Value[0]);
+        Assert.Equal('b', obj.Value[1]);
+        Assert.Equal('c', obj.Value[2]);
+    }
+}

--- a/src/Tsa.Submissions.Coding.UnitTests/WebApi/Models/ValueAsCharacterModelTests.cs
+++ b/src/Tsa.Submissions.Coding.UnitTests/WebApi/Models/ValueAsCharacterModelTests.cs
@@ -1,0 +1,21 @@
+﻿using Newtonsoft.Json;
+using Tsa.Submissions.Coding.WebApi.Models;
+using Xunit;
+
+namespace Tsa.Submissions.Coding.UnitTests.WebApi.Models;
+
+public class ValueAsCharacterModelTests
+{
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public void TestSetInput_ValueAsJson_Is_Character_Array_Model_Should_Deserialize()
+    {
+        // Arrange
+        var json = "{\"value\": \"a\" }";
+
+        var obj = JsonConvert.DeserializeObject<ValueAsCharacterModel>(json);
+
+        Assert.NotNull(obj);
+        Assert.Equal('a', obj.Value);
+    }
+}

--- a/src/Tsa.Submissions.Coding.UnitTests/WebApi/Models/ValueAsCharacterModelTests.cs
+++ b/src/Tsa.Submissions.Coding.UnitTests/WebApi/Models/ValueAsCharacterModelTests.cs
@@ -1,9 +1,11 @@
-﻿using Newtonsoft.Json;
+﻿using System.Diagnostics.CodeAnalysis;
+using Newtonsoft.Json;
 using Tsa.Submissions.Coding.WebApi.Models;
 using Xunit;
 
 namespace Tsa.Submissions.Coding.UnitTests.WebApi.Models;
 
+[ExcludeFromCodeCoverage]
 public class ValueAsCharacterModelTests
 {
     [Fact]

--- a/src/Tsa.Submissions.Coding.UnitTests/WebApi/Models/ValueAsDecimalArrayModelTests.cs
+++ b/src/Tsa.Submissions.Coding.UnitTests/WebApi/Models/ValueAsDecimalArrayModelTests.cs
@@ -1,9 +1,11 @@
 using Newtonsoft.Json;
+using System.Diagnostics.CodeAnalysis;
 using Tsa.Submissions.Coding.WebApi.Models;
 using Xunit;
 
 namespace Tsa.Submissions.Coding.UnitTests.WebApi.Models;
 
+[ExcludeFromCodeCoverage]
 public class ValueAsDecimalArrayModelTests
 {
     [Fact]

--- a/src/Tsa.Submissions.Coding.UnitTests/WebApi/Models/ValueAsDecimalArrayModelTests.cs
+++ b/src/Tsa.Submissions.Coding.UnitTests/WebApi/Models/ValueAsDecimalArrayModelTests.cs
@@ -1,0 +1,25 @@
+using Newtonsoft.Json;
+using Tsa.Submissions.Coding.WebApi.Models;
+using Xunit;
+
+namespace Tsa.Submissions.Coding.UnitTests.WebApi.Models;
+
+public class ValueAsDecimalArrayModelTests
+{
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public void TestSetInput_ValueAsJson_Is_Character_Array_Model_Should_Deserialize()
+    {
+        // Arrange
+        var json = "{ \"value\": [ 1.1, 1.2, 1.3] }";
+
+        var obj = JsonConvert.DeserializeObject<ValueAsDecimalArrayModel>(json);
+
+        Assert.NotNull(obj);
+        Assert.NotNull(obj.Value);
+        Assert.Equal(3, obj.Value.Length);
+        Assert.Equal(1.1m, obj.Value[0]);
+        Assert.Equal(1.2m, obj.Value[1]);
+        Assert.Equal(1.3m, obj.Value[2]);
+    }
+}

--- a/src/Tsa.Submissions.Coding.UnitTests/WebApi/Models/ValueAsDecimalModelTests.cs
+++ b/src/Tsa.Submissions.Coding.UnitTests/WebApi/Models/ValueAsDecimalModelTests.cs
@@ -1,0 +1,22 @@
+using Newtonsoft.Json;
+using Tsa.Submissions.Coding.WebApi.Models;
+using Xunit;
+
+namespace Tsa.Submissions.Coding.UnitTests.WebApi.Models;
+
+public class ValueAsDecimalModelTests
+{
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public void TestSetInput_ValueAsJson_Is_Character_Array_Model_Should_Deserialize()
+    {
+        // Arrange
+        var json = "{ \"value\": 1.1 }";
+
+        var obj = JsonConvert.DeserializeObject<ValueAsDecimalModel>(json);
+
+        Assert.NotNull(obj);
+        Assert.NotNull(obj.Value);
+        Assert.Equal(1.1m, obj.Value);
+    }
+}

--- a/src/Tsa.Submissions.Coding.UnitTests/WebApi/Models/ValueAsDecimalModelTests.cs
+++ b/src/Tsa.Submissions.Coding.UnitTests/WebApi/Models/ValueAsDecimalModelTests.cs
@@ -1,9 +1,11 @@
 using Newtonsoft.Json;
+using System.Diagnostics.CodeAnalysis;
 using Tsa.Submissions.Coding.WebApi.Models;
 using Xunit;
 
 namespace Tsa.Submissions.Coding.UnitTests.WebApi.Models;
 
+[ExcludeFromCodeCoverage]
 public class ValueAsDecimalModelTests
 {
     [Fact]

--- a/src/Tsa.Submissions.Coding.UnitTests/WebApi/Models/ValueAsNumberArrayModelTests.cs
+++ b/src/Tsa.Submissions.Coding.UnitTests/WebApi/Models/ValueAsNumberArrayModelTests.cs
@@ -1,9 +1,11 @@
 using Newtonsoft.Json;
+using System.Diagnostics.CodeAnalysis;
 using Tsa.Submissions.Coding.WebApi.Models;
 using Xunit;
 
 namespace Tsa.Submissions.Coding.UnitTests.WebApi.Models;
 
+[ExcludeFromCodeCoverage]
 public class ValueAsNumberArrayModelTests
 {
     [Fact]

--- a/src/Tsa.Submissions.Coding.UnitTests/WebApi/Models/ValueAsNumberArrayModelTests.cs
+++ b/src/Tsa.Submissions.Coding.UnitTests/WebApi/Models/ValueAsNumberArrayModelTests.cs
@@ -1,0 +1,25 @@
+using Newtonsoft.Json;
+using Tsa.Submissions.Coding.WebApi.Models;
+using Xunit;
+
+namespace Tsa.Submissions.Coding.UnitTests.WebApi.Models;
+
+public class ValueAsNumberArrayModelTests
+{
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public void TestSetInput_ValueAsJson_Is_Character_Array_Model_Should_Deserialize()
+    {
+        // Arrange
+        var json = "{ \"value\": [ 1, 2, 3] }";
+
+        var obj = JsonConvert.DeserializeObject<ValueAsNumberArrayModel>(json);
+
+        Assert.NotNull(obj);
+        Assert.NotNull(obj.Value);
+        Assert.Equal(3, obj.Value.Length);
+        Assert.Equal(1, obj.Value[0]);
+        Assert.Equal(2, obj.Value[1]);
+        Assert.Equal(3, obj.Value[2]);
+    }
+}

--- a/src/Tsa.Submissions.Coding.UnitTests/WebApi/Models/ValueAsNumberModelTests.cs
+++ b/src/Tsa.Submissions.Coding.UnitTests/WebApi/Models/ValueAsNumberModelTests.cs
@@ -1,0 +1,22 @@
+using Newtonsoft.Json;
+using Tsa.Submissions.Coding.WebApi.Models;
+using Xunit;
+
+namespace Tsa.Submissions.Coding.UnitTests.WebApi.Models;
+
+public class ValueAsNumberModelTests
+{
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public void TestSetInput_ValueAsJson_Is_Character_Array_Model_Should_Deserialize()
+    {
+        // Arrange
+        var json = "{ \"value\": 1 }";
+
+        var obj = JsonConvert.DeserializeObject<ValueAsNumberModel>(json);
+
+        Assert.NotNull(obj);
+        Assert.NotNull(obj.Value);
+        Assert.Equal(1, obj.Value);
+    }
+}

--- a/src/Tsa.Submissions.Coding.UnitTests/WebApi/Models/ValueAsNumberModelTests.cs
+++ b/src/Tsa.Submissions.Coding.UnitTests/WebApi/Models/ValueAsNumberModelTests.cs
@@ -1,9 +1,11 @@
 using Newtonsoft.Json;
+using System.Diagnostics.CodeAnalysis;
 using Tsa.Submissions.Coding.WebApi.Models;
 using Xunit;
 
 namespace Tsa.Submissions.Coding.UnitTests.WebApi.Models;
 
+[ExcludeFromCodeCoverage]
 public class ValueAsNumberModelTests
 {
     [Fact]

--- a/src/Tsa.Submissions.Coding.UnitTests/WebApi/Models/ValueAsStringArrayModelTests.cs
+++ b/src/Tsa.Submissions.Coding.UnitTests/WebApi/Models/ValueAsStringArrayModelTests.cs
@@ -1,0 +1,25 @@
+using Newtonsoft.Json;
+using Tsa.Submissions.Coding.WebApi.Models;
+using Xunit;
+
+namespace Tsa.Submissions.Coding.UnitTests.WebApi.Models;
+
+public class ValueAsStringArrayModelTests
+{
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public void TestSetInput_ValueAsJson_Is_Character_Array_Model_Should_Deserialize()
+    {
+        // Arrange
+        var json = "{ \"value\": [ \"1\", \"2\", \"3\"] }";
+
+        var obj = JsonConvert.DeserializeObject<ValueAsStringArrayModel>(json);
+
+        Assert.NotNull(obj);
+        Assert.NotNull(obj.Value);
+        Assert.Equal(3, obj.Value.Length);
+        Assert.Equal("1", obj.Value[0]);
+        Assert.Equal("2", obj.Value[1]);
+        Assert.Equal("3", obj.Value[2]);
+    }
+}

--- a/src/Tsa.Submissions.Coding.UnitTests/WebApi/Models/ValueAsStringArrayModelTests.cs
+++ b/src/Tsa.Submissions.Coding.UnitTests/WebApi/Models/ValueAsStringArrayModelTests.cs
@@ -1,9 +1,11 @@
 using Newtonsoft.Json;
+using System.Diagnostics.CodeAnalysis;
 using Tsa.Submissions.Coding.WebApi.Models;
 using Xunit;
 
 namespace Tsa.Submissions.Coding.UnitTests.WebApi.Models;
 
+[ExcludeFromCodeCoverage]
 public class ValueAsStringArrayModelTests
 {
     [Fact]

--- a/src/Tsa.Submissions.Coding.UnitTests/WebApi/Models/ValueAsStringModelTests.cs
+++ b/src/Tsa.Submissions.Coding.UnitTests/WebApi/Models/ValueAsStringModelTests.cs
@@ -1,9 +1,11 @@
 using Newtonsoft.Json;
+using System.Diagnostics.CodeAnalysis;
 using Tsa.Submissions.Coding.WebApi.Models;
 using Xunit;
 
 namespace Tsa.Submissions.Coding.UnitTests.WebApi.Models;
 
+[ExcludeFromCodeCoverage]
 public class ValueAsStringModelTests
 {
     [Fact]

--- a/src/Tsa.Submissions.Coding.UnitTests/WebApi/Models/ValueAsStringModelTests.cs
+++ b/src/Tsa.Submissions.Coding.UnitTests/WebApi/Models/ValueAsStringModelTests.cs
@@ -1,0 +1,22 @@
+using Newtonsoft.Json;
+using Tsa.Submissions.Coding.WebApi.Models;
+using Xunit;
+
+namespace Tsa.Submissions.Coding.UnitTests.WebApi.Models;
+
+public class ValueAsStringModelTests
+{
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public void TestSetInput_ValueAsJson_Is_Character_Array_Model_Should_Deserialize()
+    {
+        // Arrange
+        var json = "{ \"value\": \"1\" }";
+
+        var obj = JsonConvert.DeserializeObject<ValueAsStringModel>(json);
+
+        Assert.NotNull(obj);
+        Assert.NotNull(obj.Value);
+        Assert.Equal("1", obj.Value);
+    }
+}

--- a/src/Tsa.Submissions.Coding.UnitTests/WebApi/Services/TestSetsServiceTests.cs
+++ b/src/Tsa.Submissions.Coding.UnitTests/WebApi/Services/TestSetsServiceTests.cs
@@ -294,7 +294,7 @@ public class TestSetsServiceTests
             .ReturnsAsync(true)
             .ReturnsAsync(false);
 
-        var filterDefinitionJson = Builders<TestSet>.Filter.Eq(_ => _.Problem!.Id.AsString, problem.Id).RenderToJson();
+        var filterDefinitionJson = Builders<TestSet>.Filter.Eq(_ => _.Problem!.Id, problem.Id).RenderToJson();
 
         // If you get this error:
         // System.ArgumentNullException : Value cannot be null. (Parameter 'source')

--- a/src/Tsa.Submissions.Coding.UnitTests/WebApi/Services/TestSetsServiceTests.cs
+++ b/src/Tsa.Submissions.Coding.UnitTests/WebApi/Services/TestSetsServiceTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using Microsoft.Extensions.Options;
@@ -14,6 +15,7 @@ using Xunit;
 
 namespace Tsa.Submissions.Coding.UnitTests.WebApi.Services;
 
+[ExcludeFromCodeCoverage]
 public class TestSetsServiceTests
 {
     private const string CollectionName = "test-sets";

--- a/src/Tsa.Submissions.Coding.UnitTests/WebApi/Services/TestSetsServiceTests.cs
+++ b/src/Tsa.Submissions.Coding.UnitTests/WebApi/Services/TestSetsServiceTests.cs
@@ -1,0 +1,621 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using Microsoft.Extensions.Options;
+using MongoDB.Driver;
+using Moq;
+using Tsa.Submissions.Coding.UnitTests.Data;
+using Tsa.Submissions.Coding.UnitTests.ExtensionMethods;
+using Tsa.Submissions.Coding.WebApi.Configuration;
+using Tsa.Submissions.Coding.WebApi.Entities;
+using Tsa.Submissions.Coding.WebApi.Services;
+using Xunit;
+
+namespace Tsa.Submissions.Coding.UnitTests.WebApi.Services;
+
+public class TestSetsServiceTests
+{
+    private const string CollectionName = "test-sets";
+    private const string DatabaseName = "submissions";
+
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public void Collection_Name_Should_Be_TestSets()
+    {
+        // Arrange
+        var mockedMongoCollection = new Mock<IMongoCollection<TestSet>>();
+
+        var mockedMongoDatabase = new Mock<IMongoDatabase>();
+        mockedMongoDatabase
+            .Setup(_ => _.GetCollection<TestSet>(It.Is<string>(collectionName => collectionName == CollectionName), null))
+            .Returns(mockedMongoCollection.Object);
+
+        var mockedMongoClient = new Mock<IMongoClient>();
+        mockedMongoClient
+            .Setup(_ => _.GetDatabase(It.Is<string>(databaseName => databaseName == DatabaseName), null))
+            .Returns(mockedMongoDatabase.Object);
+
+        var mockedPointOfSalesOptions = new Mock<IOptions<SubmissionsDatabase>>();
+        mockedPointOfSalesOptions
+            .Setup(_ => _.Value)
+            .Returns(new SubmissionsDatabase
+            {
+                DatabaseName = DatabaseName
+            });
+
+        // Act
+        var testSetsService = new TestSetsService(mockedMongoClient.Object, mockedPointOfSalesOptions.Object);
+
+        // Assert
+        Assert.Equal(CollectionName, testSetsService.CollectionName);
+    }
+
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public void Constructor_Should_Instantiate_Base_Class()
+    {
+        // Arrange
+        var mockedMongoCollection = new Mock<IMongoCollection<TestSet>>();
+
+        var mockedMongoDatabase = new Mock<IMongoDatabase>();
+        mockedMongoDatabase
+            .Setup(_ => _.GetCollection<TestSet>(It.Is<string>(collectionName => collectionName == CollectionName), null))
+            .Returns(mockedMongoCollection.Object);
+
+        var mockedMongoClient = new Mock<IMongoClient>();
+        mockedMongoClient
+            .Setup(_ => _.GetDatabase(It.Is<string>(databaseName => databaseName == DatabaseName), null))
+            .Returns(mockedMongoDatabase.Object);
+
+        var mockedPointOfSalesOptions = new Mock<IOptions<SubmissionsDatabase>>();
+        mockedPointOfSalesOptions
+            .Setup(_ => _.Value)
+            .Returns(new SubmissionsDatabase
+            {
+                DatabaseName = DatabaseName
+            });
+
+        // Act
+        var testSetsService = new TestSetsService(mockedMongoClient.Object, mockedPointOfSalesOptions.Object);
+
+        // Assert
+        Assert.NotNull(testSetsService);
+    }
+
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public async void CreateAsync_Should_Insert_New_Entity()
+    {
+        // Arrange
+        var testSetsTestData = new TestSetsTestData();
+
+        var testSet = testSetsTestData.First(_ => (TestSetDataIssues) _[1] == TestSetDataIssues.None)[0] as TestSet;
+
+        var mockedMongoCollection = new Mock<IMongoCollection<TestSet>>();
+        //mockedMongoCollection.Setup(_=>_.InsertOneAsync())
+
+        var mockedMongoDatabase = new Mock<IMongoDatabase>();
+        mockedMongoDatabase
+            .Setup(_ => _.GetCollection<TestSet>(It.Is<string>(collectionName => collectionName == CollectionName), null))
+            .Returns(mockedMongoCollection.Object)
+            .Verifiable();
+
+        var mockedMongoClient = new Mock<IMongoClient>();
+        mockedMongoClient
+            .Setup(_ => _.GetDatabase(It.Is<string>(databaseName => databaseName == DatabaseName), null))
+            .Returns(mockedMongoDatabase.Object)
+            .Verifiable();
+
+        var mockedPointOfSalesOptions = new Mock<IOptions<SubmissionsDatabase>>();
+        mockedPointOfSalesOptions
+            .Setup(_ => _.Value)
+            .Returns(new SubmissionsDatabase
+            {
+                DatabaseName = DatabaseName
+            });
+
+        Func<TestSet, bool> validateTestSet = testSetToValidate =>
+        {
+            var inputsMatch = testSetToValidate.Inputs!.Count == testSet!.Inputs!.Count;
+            var idsMatch = testSetToValidate.Id == testSet.Id;
+            var isPublicMatch = testSetToValidate.IsPublic == testSet.IsPublic;
+            var namesMatch = testSetToValidate.Name == testSet.Name;
+            var problemsMatch = testSetToValidate.Problem == testSet.Problem;
+
+            return inputsMatch && idsMatch && isPublicMatch && namesMatch && problemsMatch;
+        };
+
+        var testSetsService = new TestSetsService(mockedMongoClient.Object, mockedPointOfSalesOptions.Object);
+
+        // Act
+        await testSetsService.CreateAsync(testSet!);
+
+        // Assert
+        mockedMongoCollection
+            .Verify(_ =>
+                _.InsertOneAsync(It.Is<TestSet>(c => validateTestSet(c)), null, CancellationToken.None), Times.Once);
+    }
+
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public async void ExistsAsync_Should_Return_True()
+    {
+        // Arrange
+        var testSetsTestData = new TestSetsTestData();
+
+        var expectedTestSet = testSetsTestData
+            .Where(_ => (TestSetDataIssues) _[1] == TestSetDataIssues.None)
+            .Select(_ => _[0])
+            .Cast<TestSet>()
+            .Last();
+
+        var testSets = new List<TestSet>
+        {
+            expectedTestSet
+        };
+
+        var mockedAsyncCursor = new Mock<IAsyncCursor<TestSet>>();
+        mockedAsyncCursor.Setup(_ => _.Current).Returns(testSets);
+        mockedAsyncCursor
+            .SetupSequence(_ => _.MoveNextAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true)
+            .ReturnsAsync(false);
+
+        var filterDefinitionJson = Builders<TestSet>.Filter.Eq(_ => _.Id, expectedTestSet.Id).RenderToJson();
+
+        // If you get this error:
+        // System.ArgumentNullException : Value cannot be null. (Parameter 'source')
+        // The predicate for FindAsync changed and is causing an error
+        var mockedMongoCollection = new Mock<IMongoCollection<TestSet>>();
+        mockedMongoCollection
+            .Setup(_ => _.FindAsync(
+                It.Is<FilterDefinition<TestSet>>(filter => filter.RenderToJson().Equals(filterDefinitionJson)),
+                It.IsAny<FindOptions<TestSet, TestSet>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(mockedAsyncCursor.Object)
+            .Verifiable();
+
+        var mockedMongoDatabase = new Mock<IMongoDatabase>();
+        mockedMongoDatabase
+            .Setup(_ => _.GetCollection<TestSet>(It.Is<string>(collectionName => collectionName == CollectionName), null))
+            .Returns(mockedMongoCollection.Object);
+
+        var mockedMongoClient = new Mock<IMongoClient>();
+        mockedMongoClient
+            .Setup(_ => _.GetDatabase(It.Is<string>(databaseName => databaseName == DatabaseName), null))
+            .Returns(mockedMongoDatabase.Object)
+            .Verifiable();
+
+        var mockedPointOfSalesOptions = new Mock<IOptions<SubmissionsDatabase>>();
+        mockedPointOfSalesOptions
+            .Setup(_ => _.Value)
+            .Returns(new SubmissionsDatabase
+            {
+                DatabaseName = DatabaseName
+            });
+
+        var testSetsService = new TestSetsService(mockedMongoClient.Object, mockedPointOfSalesOptions.Object);
+
+        // Act
+        var result = await testSetsService.ExistsAsync(expectedTestSet.Id!);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public async void GetAsync_Should_Get_All_Entities()
+    {
+        // Arrange
+        var testSetsTestData = new TestSetsTestData();
+
+        var testSets = testSetsTestData
+            .Where(_ => (TestSetDataIssues) _[1] == TestSetDataIssues.None)
+            .Select(_ => _[0])
+            .Cast<TestSet>()
+            .ToList();
+
+        var mockedAsyncCursor = new Mock<IAsyncCursor<TestSet>>();
+        mockedAsyncCursor.Setup(_ => _.Current).Returns(testSets);
+        mockedAsyncCursor
+            .SetupSequence(_ => _.MoveNextAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true)
+            .ReturnsAsync(false);
+
+        // If you get this error:
+        // System.ArgumentNullException : Value cannot be null. (Parameter 'source')
+        // The predicate for FindAsync changed and is causing an error
+        var mockedMongoCollection = new Mock<IMongoCollection<TestSet>>();
+        mockedMongoCollection
+            .Setup(_ => _.FindAsync(
+                Builders<TestSet>.Filter.Empty,
+                It.IsAny<FindOptions<TestSet, TestSet>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(mockedAsyncCursor.Object)
+            .Verifiable();
+
+        var mockedMongoDatabase = new Mock<IMongoDatabase>();
+        mockedMongoDatabase
+            .Setup(_ => _.GetCollection<TestSet>(It.Is<string>(collectionName => collectionName == CollectionName), null))
+            .Returns(mockedMongoCollection.Object);
+
+        var mockedMongoClient = new Mock<IMongoClient>();
+        mockedMongoClient
+            .Setup(_ => _.GetDatabase(It.Is<string>(databaseName => databaseName == DatabaseName), null))
+            .Returns(mockedMongoDatabase.Object)
+            .Verifiable();
+
+        var mockedPointOfSalesOptions = new Mock<IOptions<SubmissionsDatabase>>();
+        mockedPointOfSalesOptions
+            .Setup(_ => _.Value)
+            .Returns(new SubmissionsDatabase
+            {
+                DatabaseName = DatabaseName
+            });
+
+        var testSetsService = new TestSetsService(mockedMongoClient.Object, mockedPointOfSalesOptions.Object);
+
+        // Act
+        var result = await testSetsService.GetAsync();
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.NotEmpty(result);
+        Assert.Equal(testSets.Count, result.Count);
+    }
+
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public async void GetAsync_Should_Get_Entity_By_Id()
+    {
+        // Arrange
+        var testSetsTestData = new TestSetsTestData();
+
+        var expectedTestSet = testSetsTestData
+            .Where(_ => (TestSetDataIssues) _[1] == TestSetDataIssues.None)
+            .Select(_ => _[0])
+            .Cast<TestSet>()
+            .Last();
+
+        var testSets = new List<TestSet>
+        {
+            expectedTestSet
+        };
+
+        var mockedAsyncCursor = new Mock<IAsyncCursor<TestSet>>();
+        mockedAsyncCursor.Setup(_ => _.Current).Returns(testSets);
+        mockedAsyncCursor
+            .SetupSequence(_ => _.MoveNextAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true)
+            .ReturnsAsync(false);
+
+        var filterDefinitionJson = Builders<TestSet>.Filter.Eq(_ => _.Id, expectedTestSet.Id).RenderToJson();
+
+        // If you get this error:
+        // System.ArgumentNullException : Value cannot be null. (Parameter 'source')
+        // The predicate for FindAsync changed and is causing an error
+        var mockedMongoCollection = new Mock<IMongoCollection<TestSet>>();
+        mockedMongoCollection
+            .Setup(_ => _.FindAsync(
+                It.Is<FilterDefinition<TestSet>>(filter => filter.RenderToJson().Equals(filterDefinitionJson)),
+                It.IsAny<FindOptions<TestSet, TestSet>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(mockedAsyncCursor.Object)
+            .Verifiable();
+
+        var mockedMongoDatabase = new Mock<IMongoDatabase>();
+        mockedMongoDatabase
+            .Setup(_ => _.GetCollection<TestSet>(It.Is<string>(collectionName => collectionName == CollectionName), null))
+            .Returns(mockedMongoCollection.Object);
+
+        var mockedMongoClient = new Mock<IMongoClient>();
+        mockedMongoClient
+            .Setup(_ => _.GetDatabase(It.Is<string>(databaseName => databaseName == DatabaseName), null))
+            .Returns(mockedMongoDatabase.Object)
+            .Verifiable();
+
+        var mockedPointOfSalesOptions = new Mock<IOptions<SubmissionsDatabase>>();
+        mockedPointOfSalesOptions
+            .Setup(_ => _.Value)
+            .Returns(new SubmissionsDatabase
+            {
+                DatabaseName = DatabaseName
+            });
+
+        var testSetsService = new TestSetsService(mockedMongoClient.Object, mockedPointOfSalesOptions.Object);
+
+        // Act
+        var result = await testSetsService.GetAsync(expectedTestSet.Id!);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(expectedTestSet, result);
+    }
+
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public async void GetAsync_Should_Get_Entity_By_Ids()
+    {
+        // Arrange
+        var testSetsTestData = new TestSetsTestData();
+
+        var expectedTestSets = testSetsTestData
+            .Where(_ => (TestSetDataIssues) _[1] == TestSetDataIssues.None)
+            .Select(_ => _[0])
+            .Cast<TestSet>()
+            .ToList();
+
+        var ids = expectedTestSets.Select(_ => _.Id).Cast<string>().ToList();
+
+        var mockedAsyncCursor = new Mock<IAsyncCursor<TestSet>>();
+        mockedAsyncCursor.Setup(_ => _.Current).Returns(expectedTestSets);
+        mockedAsyncCursor
+            .SetupSequence(_ => _.MoveNextAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true)
+            .ReturnsAsync(false);
+
+        var filterDefinitionJson = Builders<TestSet>.Filter.In(_ => _.Id, ids).RenderToJson();
+
+        // If you get this error:
+        // System.ArgumentNullException : Value cannot be null. (Parameter 'source')
+        // The predicate for FindAsync changed and is causing an error
+        var mockedMongoCollection = new Mock<IMongoCollection<TestSet>>();
+        mockedMongoCollection
+            .Setup(_ => _.FindAsync(
+                It.Is<FilterDefinition<TestSet>>(filter => filter.RenderToJson().Equals(filterDefinitionJson)),
+                It.IsAny<FindOptions<TestSet, TestSet>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(mockedAsyncCursor.Object)
+            .Verifiable();
+
+        var mockedMongoDatabase = new Mock<IMongoDatabase>();
+        mockedMongoDatabase
+            .Setup(_ => _.GetCollection<TestSet>(It.Is<string>(collectionName => collectionName == CollectionName), null))
+            .Returns(mockedMongoCollection.Object);
+
+        var mockedMongoClient = new Mock<IMongoClient>();
+        mockedMongoClient
+            .Setup(_ => _.GetDatabase(It.Is<string>(databaseName => databaseName == DatabaseName), null))
+            .Returns(mockedMongoDatabase.Object)
+            .Verifiable();
+
+        var mockedPointOfSalesOptions = new Mock<IOptions<SubmissionsDatabase>>();
+        mockedPointOfSalesOptions
+            .Setup(_ => _.Value)
+            .Returns(new SubmissionsDatabase
+            {
+                DatabaseName = DatabaseName
+            });
+
+        var testSetsService = new TestSetsService(mockedMongoClient.Object, mockedPointOfSalesOptions.Object);
+
+        // Act
+        var result = await testSetsService.GetAsync(ids);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(expectedTestSets.Count, result.Count);
+    }
+
+
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public async void Ping_Should_Return_False()
+    {
+        // Arrange
+        var mockedMongoDatabase = new Mock<IMongoDatabase>();
+
+        var mockedMongoClient = new Mock<IMongoClient>();
+        mockedMongoClient
+            .Setup(_ => _.GetDatabase(It.Is<string>(databaseName => databaseName == DatabaseName), null))
+            .Returns(mockedMongoDatabase.Object)
+            .Verifiable();
+
+        var mockedPointOfSalesOptions = new Mock<IOptions<SubmissionsDatabase>>();
+        mockedPointOfSalesOptions
+            .Setup(_ => _.Value)
+            .Returns(new SubmissionsDatabase
+            {
+                DatabaseName = DatabaseName
+            });
+
+        var testSetsService = new TestSetsService(mockedMongoClient.Object, mockedPointOfSalesOptions.Object);
+
+        // Act
+        var result = await testSetsService.PingAsync();
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public async void Ping_Should_Return_True()
+    {
+        // Arrange
+        var mockedMongoCollection = new Mock<IMongoCollection<TestSet>>();
+        var mockedMongoDatabase = new Mock<IMongoDatabase>();
+
+        mockedMongoCollection
+            .Setup(_ => _.Database)
+            .Returns(mockedMongoDatabase.Object);
+
+        mockedMongoDatabase
+            .Setup(_ => _.GetCollection<TestSet>(It.Is<string>(collectionName => collectionName == CollectionName), null))
+            .Returns(mockedMongoCollection.Object);
+
+        var mockedMongoClient = new Mock<IMongoClient>();
+        mockedMongoClient
+            .Setup(_ => _.GetDatabase(It.Is<string>(databaseName => databaseName == DatabaseName), null))
+            .Returns(mockedMongoDatabase.Object)
+            .Verifiable();
+
+        var mockedPointOfSalesOptions = new Mock<IOptions<SubmissionsDatabase>>();
+        mockedPointOfSalesOptions
+            .Setup(_ => _.Value)
+            .Returns(new SubmissionsDatabase
+            {
+                DatabaseName = DatabaseName
+            });
+
+        var testSetsService = new TestSetsService(mockedMongoClient.Object, mockedPointOfSalesOptions.Object);
+
+        // Act
+        var result = await testSetsService.PingAsync();
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public async void RemoveAsync_Should_Delete_Entity_By_Id()
+    {
+        // Arrange
+        var testSetsTestData = new TestSetsTestData();
+
+        var expectedTestSet = testSetsTestData
+            .Where(_ => (TestSetDataIssues) _[1] == TestSetDataIssues.None)
+            .Select(_ => _[0])
+            .Cast<TestSet>()
+            .Last();
+
+        var expectedFilterDefinitionJson = Builders<TestSet>.Filter.Eq(_ => _.Id, expectedTestSet.Id).RenderToJson();
+
+        Func<FilterDefinition<TestSet>, bool> validateFilterDefinitionFunc = filterDefinition =>
+        {
+            var filterDefinitionJson = filterDefinition.RenderToJson();
+
+            return expectedFilterDefinitionJson == filterDefinitionJson;
+        };
+
+        // If you get this error:
+        // System.ArgumentNullException : Value cannot be null. (Parameter 'source')
+        // The predicate for FindAsync changed and is causing an error
+        var mockedMongoCollection = new Mock<IMongoCollection<TestSet>>();
+
+        var mockedMongoDatabase = new Mock<IMongoDatabase>();
+        mockedMongoDatabase
+            .Setup(_ => _.GetCollection<TestSet>(It.Is<string>(collectionName => collectionName == CollectionName), null))
+            .Returns(mockedMongoCollection.Object);
+
+        var mockedMongoClient = new Mock<IMongoClient>();
+        mockedMongoClient
+            .Setup(_ => _.GetDatabase(It.Is<string>(databaseName => databaseName == DatabaseName), null))
+            .Returns(mockedMongoDatabase.Object)
+            .Verifiable();
+
+        var mockedPointOfSalesOptions = new Mock<IOptions<SubmissionsDatabase>>();
+        mockedPointOfSalesOptions
+            .Setup(_ => _.Value)
+            .Returns(new SubmissionsDatabase
+            {
+                DatabaseName = DatabaseName
+            });
+
+        var testSetsService = new TestSetsService(mockedMongoClient.Object, mockedPointOfSalesOptions.Object);
+
+        // Act
+        await testSetsService.RemoveAsync(expectedTestSet);
+
+        // Assert
+        mockedMongoCollection
+            .Verify(_ => _.DeleteOneAsync(
+                    It.Is<FilterDefinition<TestSet>>(fd => validateFilterDefinitionFunc(fd)),
+                    null,
+                    It.IsAny<CancellationToken>()),
+                Times.Once);
+    }
+
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public void ServiceName_Name_Should_Be_TestSets()
+    {
+        // Arrange
+        var mockedMongoCollection = new Mock<IMongoCollection<TestSet>>();
+
+        var mockedMongoDatabase = new Mock<IMongoDatabase>();
+        mockedMongoDatabase
+            .Setup(_ => _.GetCollection<TestSet>(It.Is<string>(collectionName => collectionName == CollectionName), null))
+            .Returns(mockedMongoCollection.Object);
+
+        var mockedMongoClient = new Mock<IMongoClient>();
+        mockedMongoClient
+            .Setup(_ => _.GetDatabase(It.Is<string>(databaseName => databaseName == DatabaseName), null))
+            .Returns(mockedMongoDatabase.Object);
+
+        var mockedPointOfSalesOptions = new Mock<IOptions<SubmissionsDatabase>>();
+        mockedPointOfSalesOptions
+            .Setup(_ => _.Value)
+            .Returns(new SubmissionsDatabase
+            {
+                DatabaseName = DatabaseName
+            });
+
+        // Act
+        var testSetsService = new TestSetsService(mockedMongoClient.Object, mockedPointOfSalesOptions.Object);
+
+        // Assert
+        Assert.Equal("TestSets", testSetsService.ServiceName);
+    }
+
+    [Fact]
+    [Trait("TestCategory", "UnitTest")]
+    public async void UpdateAsync_Should_Replace_Entity_By_Id()
+    {
+        // Arrange
+        var testSetsTestData = new TestSetsTestData();
+
+        var expectedTestSet = testSetsTestData
+            .Where(_ => (TestSetDataIssues) _[1] == TestSetDataIssues.None)
+            .Select(_ => _[0])
+            .Cast<TestSet>()
+            .Last();
+
+        var expectedFilterDefinitionJson = Builders<TestSet>.Filter.Eq(_ => _.Id, expectedTestSet.Id).RenderToJson();
+
+        Func<FilterDefinition<TestSet>, bool> validateFilterDefinitionFunc = filterDefinition =>
+        {
+            var filterDefinitionJson = filterDefinition.RenderToJson();
+
+            return expectedFilterDefinitionJson == filterDefinitionJson;
+        };
+
+        var mockedMongoCollection = new Mock<IMongoCollection<TestSet>>();
+
+        var mockedMongoDatabase = new Mock<IMongoDatabase>();
+        mockedMongoDatabase
+            .Setup(_ => _.GetCollection<TestSet>(It.Is<string>(collectionName => collectionName == CollectionName), null))
+            .Returns(mockedMongoCollection.Object);
+
+        var mockedMongoClient = new Mock<IMongoClient>();
+        mockedMongoClient
+            .Setup(_ => _.GetDatabase(It.Is<string>(databaseName => databaseName == DatabaseName), null))
+            .Returns(mockedMongoDatabase.Object)
+            .Verifiable();
+
+        var mockedPointOfSalesOptions = new Mock<IOptions<SubmissionsDatabase>>();
+        mockedPointOfSalesOptions
+            .Setup(_ => _.Value)
+            .Returns(new SubmissionsDatabase
+            {
+                DatabaseName = DatabaseName
+            });
+
+        var testSetsService = new TestSetsService(mockedMongoClient.Object, mockedPointOfSalesOptions.Object);
+
+        // Act
+        await testSetsService.UpdateAsync(expectedTestSet, default);
+
+        // Assert
+        mockedMongoCollection
+            .Verify(_ => _.ReplaceOneAsync(
+                    It.Is<FilterDefinition<TestSet>>(fd => validateFilterDefinitionFunc(fd)),
+                    expectedTestSet,
+                    It.IsAny<ReplaceOptions>(),
+                    It.IsAny<CancellationToken>()),
+                Times.Once);
+    }
+}

--- a/src/Tsa.Submissions.Coding.UnitTests/WebApi/Services/TestSetsServiceTests.cs
+++ b/src/Tsa.Submissions.Coding.UnitTests/WebApi/Services/TestSetsServiceTests.cs
@@ -92,7 +92,7 @@ public class TestSetsServiceTests
         // Arrange
         var testSetsTestData = new TestSetsTestData();
 
-        var testSet = testSetsTestData.First(_ => (TestSetDataIssues) _[1] == TestSetDataIssues.None)[0] as TestSet;
+        var testSet = testSetsTestData.First(_ => (TestSetDataIssues)_[1] == TestSetDataIssues.None)[0] as TestSet;
 
         var mockedMongoCollection = new Mock<IMongoCollection<TestSet>>();
         //mockedMongoCollection.Setup(_=>_.InsertOneAsync())
@@ -147,7 +147,7 @@ public class TestSetsServiceTests
         var testSetsTestData = new TestSetsTestData();
 
         var expectedTestSet = testSetsTestData
-            .Where(_ => (TestSetDataIssues) _[1] == TestSetDataIssues.None)
+            .Where(_ => (TestSetDataIssues)_[1] == TestSetDataIssues.None)
             .Select(_ => _[0])
             .Cast<TestSet>()
             .Last();
@@ -214,7 +214,7 @@ public class TestSetsServiceTests
         var testSetsTestData = new TestSetsTestData();
 
         var testSets = testSetsTestData
-            .Where(_ => (TestSetDataIssues) _[1] == TestSetDataIssues.None)
+            .Where(_ => (TestSetDataIssues)_[1] == TestSetDataIssues.None)
             .Select(_ => _[0])
             .Cast<TestSet>()
             .ToList();
@@ -276,7 +276,7 @@ public class TestSetsServiceTests
         var testSetsTestData = new TestSetsTestData();
 
         var expectedTestSet = testSetsTestData
-            .Where(_ => (TestSetDataIssues) _[1] == TestSetDataIssues.None)
+            .Where(_ => (TestSetDataIssues)_[1] == TestSetDataIssues.None)
             .Select(_ => _[0])
             .Cast<TestSet>()
             .Last();
@@ -344,7 +344,7 @@ public class TestSetsServiceTests
         var testSetsTestData = new TestSetsTestData();
 
         var expectedTestSets = testSetsTestData
-            .Where(_ => (TestSetDataIssues) _[1] == TestSetDataIssues.None)
+            .Where(_ => (TestSetDataIssues)_[1] == TestSetDataIssues.None)
             .Select(_ => _[0])
             .Cast<TestSet>()
             .ToList();
@@ -479,7 +479,7 @@ public class TestSetsServiceTests
         var testSetsTestData = new TestSetsTestData();
 
         var expectedTestSet = testSetsTestData
-            .Where(_ => (TestSetDataIssues) _[1] == TestSetDataIssues.None)
+            .Where(_ => (TestSetDataIssues)_[1] == TestSetDataIssues.None)
             .Select(_ => _[0])
             .Cast<TestSet>()
             .Last();
@@ -571,7 +571,7 @@ public class TestSetsServiceTests
         var testSetsTestData = new TestSetsTestData();
 
         var expectedTestSet = testSetsTestData
-            .Where(_ => (TestSetDataIssues) _[1] == TestSetDataIssues.None)
+            .Where(_ => (TestSetDataIssues)_[1] == TestSetDataIssues.None)
             .Select(_ => _[0])
             .Cast<TestSet>()
             .Last();

--- a/src/Tsa.Submissions.Coding.UnitTests/WebApi/Validators/TestSetModelValidatorTests.cs
+++ b/src/Tsa.Submissions.Coding.UnitTests/WebApi/Validators/TestSetModelValidatorTests.cs
@@ -48,5 +48,14 @@ public class TestSetModelValidatorTests
         {
             testValidationResult.ShouldNotHaveValidationErrorFor(_ => _.ProblemId);
         }
+
+        if (testSetDataIssues.HasFlag(TestSetDataIssues.MissingInput))
+        {
+            testValidationResult.ShouldHaveValidationErrorFor(_ => _.Inputs);
+        }
+        else
+        {
+            testValidationResult.ShouldNotHaveValidationErrorFor(_ => _.Inputs);
+        }
     }
 }

--- a/src/Tsa.Submissions.Coding.UnitTests/WebApi/Validators/TestSetModelValidatorTests.cs
+++ b/src/Tsa.Submissions.Coding.UnitTests/WebApi/Validators/TestSetModelValidatorTests.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FluentValidation.TestHelper;
+using Tsa.Submissions.Coding.UnitTests.Data;
+using Tsa.Submissions.Coding.WebApi.Entities;
+using Tsa.Submissions.Coding.WebApi.Validators;
+using Xunit;
+
+namespace Tsa.Submissions.Coding.UnitTests.WebApi.Validators;
+
+[ExcludeFromCodeCoverage]
+public class TestSetModelValidatorTests
+{
+    [Theory]
+    [ClassData(typeof(TestSetsTestData))]
+    [Trait("TestCategory", "UnitTest")]
+    public void Should_Successfully_Validate_TeamModel(TestSet testSet, TestSetDataIssues testSetDataIssues)
+    {
+        // Arrange
+        var teamModel = testSet.ToModel();
+
+        var testSetModelValidator = new TestSetModelValidator();
+
+        // Act
+
+        var testValidationResult = testSetModelValidator.TestValidate(teamModel);
+
+        // Assert
+
+        if (testSetDataIssues.HasFlag(TestSetDataIssues.MissingName))
+        {
+            testValidationResult.ShouldHaveValidationErrorFor(_ => _.Name);
+        }
+        else
+        {
+            testValidationResult.ShouldNotHaveValidationErrorFor(_ => _.Name);
+        }
+
+        if (testSetDataIssues.HasFlag(TestSetDataIssues.MissingProblemId))
+        {
+            testValidationResult.ShouldHaveValidationErrorFor(_ => _.ProblemId);
+        }
+        else
+        {
+            testValidationResult.ShouldNotHaveValidationErrorFor(_ => _.ProblemId);
+        }
+    }
+}

--- a/src/Tsa.Submissions.Coding.UnitTests/WebApi/Validators/TestSetModelValidatorTests.cs
+++ b/src/Tsa.Submissions.Coding.UnitTests/WebApi/Validators/TestSetModelValidatorTests.cs
@@ -51,7 +51,8 @@ public class TestSetModelValidatorTests
             testSetDataIssues.HasFlag(TestSetDataIssues.IndexNotUnique) ||
             testSetDataIssues.HasFlag(TestSetDataIssues.MissingValueAsJson) ||
             testSetDataIssues.HasFlag(TestSetDataIssues.ValueDoesNotMatchDataType) ||
-            testSetDataIssues.HasFlag(TestSetDataIssues.ValueCannotBeDeserialized))
+            testSetDataIssues.HasFlag(TestSetDataIssues.ValueCannotBeDeserialized) ||
+            testSetDataIssues.HasFlag(TestSetDataIssues.IndexNotContinuous))
         {
             testValidationResult.ShouldHaveValidationErrorFor(_ => _.Inputs);
         }

--- a/src/Tsa.Submissions.Coding.UnitTests/WebApi/Validators/TestSetModelValidatorTests.cs
+++ b/src/Tsa.Submissions.Coding.UnitTests/WebApi/Validators/TestSetModelValidatorTests.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Diagnostics.CodeAnalysis;
 using FluentValidation.TestHelper;
 using Tsa.Submissions.Coding.UnitTests.Data;
 using Tsa.Submissions.Coding.WebApi.Entities;
@@ -49,7 +44,14 @@ public class TestSetModelValidatorTests
             testValidationResult.ShouldNotHaveValidationErrorFor(_ => _.ProblemId);
         }
 
-        if (testSetDataIssues.HasFlag(TestSetDataIssues.MissingInput))
+        if (testSetDataIssues.HasFlag(TestSetDataIssues.MissingInput) ||
+            testSetDataIssues.HasFlag(TestSetDataIssues.MissingDataType) ||
+            testSetDataIssues.HasFlag(TestSetDataIssues.InvalidDataType) ||
+            testSetDataIssues.HasFlag(TestSetDataIssues.MissingIndex) ||
+            testSetDataIssues.HasFlag(TestSetDataIssues.IndexNotUnique) ||
+            testSetDataIssues.HasFlag(TestSetDataIssues.MissingValueAsJson) ||
+            testSetDataIssues.HasFlag(TestSetDataIssues.ValueDoesNotMatchDataType) ||
+            testSetDataIssues.HasFlag(TestSetDataIssues.ValueCannotBeDeserialized))
         {
             testValidationResult.ShouldHaveValidationErrorFor(_ => _.Inputs);
         }

--- a/src/Tsa.Submissions.Coding.WebApi/Controllers/ProblemsController.cs
+++ b/src/Tsa.Submissions.Coding.WebApi/Controllers/ProblemsController.cs
@@ -39,7 +39,7 @@ public class ProblemsController : ControllerBase
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> Delete(string id, CancellationToken cancellationToken)
+    public async Task<IActionResult> Delete(string id, CancellationToken cancellationToken = default)
     {
         var problem = await _problemsService.GetAsync(id, cancellationToken);
 
@@ -132,7 +132,7 @@ public class ProblemsController : ControllerBase
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<TestSetModel>))]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<ActionResult<IList<TestSetModel>>> GetTestSets(string id, CancellationToken cancellationToken)
+    public async Task<ActionResult<IList<TestSetModel>>> GetTestSets(string id, CancellationToken cancellationToken = default)
     {
         var problem = await _problemsService.GetAsync(id, cancellationToken);
 
@@ -158,7 +158,7 @@ public class ProblemsController : ControllerBase
     [ProducesResponseType(StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(ValidationProblemDetails))]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
-    public async Task<CreatedAtActionResult> Post(ProblemModel problemModel, CancellationToken cancellationToken)
+    public async Task<CreatedAtActionResult> Post(ProblemModel problemModel, CancellationToken cancellationToken = default)
     {
         var problem = problemModel.ToEntity();
 
@@ -184,7 +184,7 @@ public class ProblemsController : ControllerBase
     [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(ValidationProblemDetails))]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> Put(string id, ProblemModel updatedProblemModel, CancellationToken cancellationToken)
+    public async Task<IActionResult> Put(string id, ProblemModel updatedProblemModel, CancellationToken cancellationToken = default)
     {
         var problem = await _problemsService.GetAsync(id, cancellationToken);
 

--- a/src/Tsa.Submissions.Coding.WebApi/Controllers/TestSetsController.cs
+++ b/src/Tsa.Submissions.Coding.WebApi/Controllers/TestSetsController.cs
@@ -40,7 +40,7 @@ public class TestSetsController : ControllerBase
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> Delete(string id, CancellationToken cancellationToken)
+    public async Task<IActionResult> Delete(string id, CancellationToken cancellationToken = default)
     {
         var testSet = await _testSetsService.GetAsync(id, cancellationToken);
 
@@ -67,7 +67,7 @@ public class TestSetsController : ControllerBase
     [Authorize(Roles = SubmissionRoles.All)]
     [HttpGet]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<TestSetModel>))]
-    public async Task<ActionResult<IList<TestSetModel>>> Get(CancellationToken cancellationToken)
+    public async Task<ActionResult<IList<TestSetModel>>> Get(CancellationToken cancellationToken = default)
     {
         var testSets = await _testSetsService.GetAsync(cancellationToken);
 
@@ -87,7 +87,7 @@ public class TestSetsController : ControllerBase
     [HttpGet("{id:length(24)}")]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(TestSetModel))]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<ActionResult<TestSetModel>> Get(string id, CancellationToken cancellationToken)
+    public async Task<ActionResult<TestSetModel>> Get(string id, CancellationToken cancellationToken = default)
     {
         var testSet = await _testSetsService.GetAsync(id, cancellationToken);
 
@@ -115,7 +115,7 @@ public class TestSetsController : ControllerBase
     [ProducesResponseType(StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(ValidationProblemDetails))]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
-    public async Task<CreatedAtActionResult> Post(TestSetModel testSetModel, CancellationToken cancellationToken)
+    public async Task<CreatedAtActionResult> Post(TestSetModel testSetModel, CancellationToken cancellationToken = default)
     {
         // The ProblemModelValidator will ensure ProblemId is not null
         await EnsureProblemExists(testSetModel.ProblemId!, nameof(TestSetModel.ProblemId));
@@ -144,7 +144,7 @@ public class TestSetsController : ControllerBase
     [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(ValidationProblemDetails))]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> Put(string id, TestSetModel updatedTestSetModel, CancellationToken cancellationToken)
+    public async Task<IActionResult> Put(string id, TestSetModel updatedTestSetModel, CancellationToken cancellationToken = default)
     {
         // The ProblemModelValidator will ensure ProblemId is not null
         await EnsureProblemExists(updatedTestSetModel.ProblemId!, nameof(TestSetModel.ProblemId));

--- a/src/Tsa.Submissions.Coding.WebApi/Controllers/TestSetsController.cs
+++ b/src/Tsa.Submissions.Coding.WebApi/Controllers/TestSetsController.cs
@@ -1,0 +1,162 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Tsa.Submissions.Coding.WebApi.Authorization;
+using Tsa.Submissions.Coding.WebApi.Entities;
+using Tsa.Submissions.Coding.WebApi.Exceptions;
+using Tsa.Submissions.Coding.WebApi.Models;
+using Tsa.Submissions.Coding.WebApi.Services;
+
+namespace Tsa.Submissions.Coding.WebApi.Controllers;
+
+[Route("api/[controller]")]
+[ApiController]
+[Produces("application/json")]
+public class TestSetsController : ControllerBase
+{
+    private readonly IProblemsService _problemsService;
+    private readonly ITestSetsService _testSetsService;
+
+    public TestSetsController(IProblemsService problemsService, ITestSetsService testSetsService)
+    {
+        _problemsService = problemsService;
+        _testSetsService = testSetsService;
+    }
+
+    /// <summary>
+    ///     Deletes a testSet from database
+    /// </summary>
+    /// <param name="id">The ID of the testSet to be removed</param>
+    /// <param name="cancellationToken">The .NET cancellation token</param>
+    /// <response code="204">Acknowledges the testSet was successfully removed</response>
+    /// <response code="403">You do not have permission to use this endpoint</response>
+    /// <response code="404">The testSet to remove does not exist in the database</response>
+    [Authorize(Roles = SubmissionRoles.Judge)]
+    [HttpDelete("{id:length(24)}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Delete(string id, CancellationToken cancellationToken)
+    {
+        var testSet = await _testSetsService.GetAsync(id, cancellationToken);
+
+        if (testSet == null) return NotFound();
+
+        await _testSetsService.RemoveAsync(testSet, cancellationToken);
+
+        return NoContent();
+    }
+
+    private async Task EnsureProblemExists(string problemId, string attributeName)
+    {
+        if (!await _problemsService.ExistsAsync(problemId))
+        {
+            throw new RequiredEntityNotFoundException(attributeName);
+        }
+    }
+
+    /// <summary>
+    ///     Fetches all the testSets from the database
+    /// </summary>
+    /// <param name="cancellationToken">The .NET cancellation token</param>
+    /// <response code="200">All available testSets returned</response>
+    [Authorize(Roles = SubmissionRoles.All)]
+    [HttpGet]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<TestSetModel>))]
+    public async Task<ActionResult<IList<TestSetModel>>> Get(CancellationToken cancellationToken)
+    {
+        var testSets = await _testSetsService.GetAsync(cancellationToken);
+
+        return User.IsInRole(SubmissionRoles.Participant)
+            ? testSets.ToModels().Where(_ => _.IsPublic).ToList()
+            : testSets.ToModels();
+    }
+
+    /// <summary>
+    ///     Fetches a testSet from the database
+    /// </summary>
+    /// <param name="id">The ID of the testSet to get</param>
+    /// <param name="cancellationToken">The .NET cancellation token</param>
+    /// <response code="200">Returns the requested testSet</response>
+    /// <response code="404">The testSet does not exist in the database</response>
+    [Authorize(Roles = SubmissionRoles.All)]
+    [HttpGet("{id:length(24)}")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(TestSetModel))]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<TestSetModel>> Get(string id, CancellationToken cancellationToken)
+    {
+        var testSet = await _testSetsService.GetAsync(id, cancellationToken);
+
+        if (testSet == null) return NotFound();
+
+        if (User.IsInRole(SubmissionRoles.Participant) && !testSet.IsPublic)
+        {
+            // Return 404 to obfuscate the data
+            return NotFound();
+        }
+
+        return testSet.ToModel();
+    }
+
+    /// <summary>
+    ///     Creates a new testSet
+    /// </summary>
+    /// <param name="testSetModel">The testSet to be created</param>
+    /// <param name="cancellationToken">The .NET cancellation token</param>
+    /// <response code="201">Returns the requested testSet</response>
+    /// <response code="400">The testSet is not in a valid state and cannot be created</response>
+    /// <response code="403">You do not have permission to use this endpoint</response>
+    [Authorize(Roles = SubmissionRoles.Judge)]
+    [HttpPost]
+    [ProducesResponseType(StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(ValidationProblemDetails))]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<CreatedAtActionResult> Post(TestSetModel testSetModel, CancellationToken cancellationToken)
+    {
+        // The ProblemModelValidator will ensure ProblemId is not null
+        await EnsureProblemExists(testSetModel.ProblemId!, nameof(TestSetModel.ProblemId));
+
+        var testSet = testSetModel.ToEntity();
+
+        await _testSetsService.CreateAsync(testSet, cancellationToken);
+
+        testSetModel.Id = testSet.Id;
+
+        return CreatedAtAction(nameof(Get), new { id = testSet.Id }, testSetModel);
+    }
+
+    /// <summary>
+    ///     Updates the specified testSet
+    /// </summary>
+    /// <param name="id">The ID of the testSet to update</param>
+    /// <param name="updatedTestSetModel">The testSet that should replace the one in the database</param>
+    /// <param name="cancellationToken">The .NET cancellation token</param>
+    /// <response code="204">Acknowledgement that the testSet was updated</response>
+    /// <response code="400">The testSet is not in a valid state and cannot be updated</response>
+    /// <response code="404">The testSet requested to be updated could not be found</response>
+    [Authorize(Roles = SubmissionRoles.Judge)]
+    [HttpPut("{id:length(24)}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(ValidationProblemDetails))]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Put(string id, TestSetModel updatedTestSetModel, CancellationToken cancellationToken)
+    {
+        // The ProblemModelValidator will ensure ProblemId is not null
+        await EnsureProblemExists(updatedTestSetModel.ProblemId!, nameof(TestSetModel.ProblemId));
+
+        var testSet = await _testSetsService.GetAsync(id, cancellationToken);
+
+        if (testSet == null) return NotFound();
+
+        updatedTestSetModel.Id = testSet.Id;
+
+        await _testSetsService.UpdateAsync(updatedTestSetModel.ToEntity(), cancellationToken);
+
+        return NoContent();
+    }
+}

--- a/src/Tsa.Submissions.Coding.WebApi/Entities/EntityExtensions.cs
+++ b/src/Tsa.Submissions.Coding.WebApi/Entities/EntityExtensions.cs
@@ -47,6 +47,18 @@ public static class EntityExtensions
         };
     }
 
+    public static TestSetModel ToModel(this TestSet testSet)
+    {
+        return new TestSetModel
+        {
+            Id = testSet.Id,
+            Inputs = testSet.Inputs.ToModels(),
+            IsPublic = testSet.IsPublic,
+            Name = testSet.Name,
+            ProblemId = testSet.Problem?.Id.AsString
+        };
+    }
+
     public static IList<TestSetInputModel>? ToModels(this IList<TestSetInput>? testSetInputs)
     {
         return testSetInputs?.Select(testSetInput => testSetInput.ToModel()).ToList();

--- a/src/Tsa.Submissions.Coding.WebApi/Entities/EntityExtensions.cs
+++ b/src/Tsa.Submissions.Coding.WebApi/Entities/EntityExtensions.cs
@@ -43,7 +43,8 @@ public static class EntityExtensions
         {
             DataType = testSetInput.DataType,
             Index = testSetInput.Index,
-            Value = testSetInput.Value
+            IsArray = testSetInput.IsArray,
+            ValueAsJson = testSetInput.ValueAsJson
         };
     }
 
@@ -59,16 +60,6 @@ public static class EntityExtensions
         };
     }
 
-    public static List<TestSetModel> ToModels(this IList<TestSet> testSets)
-    {
-        return testSets.Select(testSet => testSet.ToModel()).ToList();
-    }
-
-    public static List<TestSetInputModel>? ToModels(this IList<TestSetInput>? testSetInputs)
-    {
-        return testSetInputs?.Select(testSetInput => testSetInput.ToModel()).ToList();
-    }
-
     public static List<ParticipantModel> ToModels(this IList<Participant> participants)
     {
         return participants.Select(participant => participant.ToModel()).ToList();
@@ -82,5 +73,15 @@ public static class EntityExtensions
     public static List<TeamModel> ToModels(this IList<Team> teams)
     {
         return teams.Select(team => team.ToModel()).ToList();
+    }
+
+    public static List<TestSetInputModel>? ToModels(this IList<TestSetInput>? testSetInputs)
+    {
+        return testSetInputs?.Select(testSetInput => testSetInput.ToModel()).ToList();
+    }
+
+    public static List<TestSetModel> ToModels(this IList<TestSet> testSets)
+    {
+        return testSets.Select(testSet => testSet.ToModel()).ToList();
     }
 }

--- a/src/Tsa.Submissions.Coding.WebApi/Entities/EntityExtensions.cs
+++ b/src/Tsa.Submissions.Coding.WebApi/Entities/EntityExtensions.cs
@@ -15,17 +15,6 @@ public static class EntityExtensions
         };
     }
 
-    public static TeamModel ToModel(this Team team)
-    {
-        return new TeamModel
-        {
-            Id = team.Id,
-            Participants = team.Participants.ToModels(),
-            SchoolNumber = team.SchoolNumber,
-            TeamNumber = team.TeamNumber
-        };
-    }
-
     public static ProblemModel ToModel(this Problem problem)
     {
         return new ProblemModel
@@ -37,18 +26,44 @@ public static class EntityExtensions
         };
     }
 
+    public static TeamModel ToModel(this Team team)
+    {
+        return new TeamModel
+        {
+            Id = team.Id,
+            Participants = team.Participants.ToModels(),
+            SchoolNumber = team.SchoolNumber,
+            TeamNumber = team.TeamNumber
+        };
+    }
+
+    public static TestSetInputModel ToModel(this TestSetInput testSetInput)
+    {
+        return new TestSetInputModel
+        {
+            DataType = testSetInput.DataType,
+            Index = testSetInput.Index,
+            Value = testSetInput.Value
+        };
+    }
+
+    public static IList<TestSetInputModel>? ToModels(this IList<TestSetInput>? testSetInputs)
+    {
+        return testSetInputs?.Select(testSetInput => testSetInput.ToModel()).ToList();
+    }
+
     public static List<ParticipantModel> ToModels(this IList<Participant> participants)
     {
         return participants.Select(participant => participant.ToModel()).ToList();
     }
 
-    public static List<TeamModel> ToModels(this IList<Team> teams)
-    {
-        return teams.Select(team => team.ToModel()).ToList();
-    }
-
     public static List<ProblemModel> ToModels(this IList<Problem> problems)
     {
         return problems.Select(problem => problem.ToModel()).ToList();
+    }
+
+    public static List<TeamModel> ToModels(this IList<Team> teams)
+    {
+        return teams.Select(team => team.ToModel()).ToList();
     }
 }

--- a/src/Tsa.Submissions.Coding.WebApi/Entities/EntityExtensions.cs
+++ b/src/Tsa.Submissions.Coding.WebApi/Entities/EntityExtensions.cs
@@ -59,7 +59,12 @@ public static class EntityExtensions
         };
     }
 
-    public static IList<TestSetInputModel>? ToModels(this IList<TestSetInput>? testSetInputs)
+    public static List<TestSetModel> ToModels(this IList<TestSet> testSets)
+    {
+        return testSets.Select(testSet => testSet.ToModel()).ToList();
+    }
+
+    public static List<TestSetInputModel>? ToModels(this IList<TestSetInput>? testSetInputs)
     {
         return testSetInputs?.Select(testSetInput => testSetInput.ToModel()).ToList();
     }

--- a/src/Tsa.Submissions.Coding.WebApi/Entities/TestSet.cs
+++ b/src/Tsa.Submissions.Coding.WebApi/Entities/TestSet.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections.Generic;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+using MongoDB.Driver;
+using Swashbuckle.AspNetCore.Annotations;
+
+namespace Tsa.Submissions.Coding.WebApi.Entities;
+
+public class TestSet : IMongoDbEntity
+{
+    [BsonId]
+    [BsonRepresentation(BsonType.ObjectId)]
+    [SwaggerSchema(ReadOnly = true)]
+    public string? Id { get; set; }
+
+    public IList<TestSetInput>? Inputs { get; set; }
+
+    public bool IsPublic { get; set; }
+
+    public string? Name { get; set; }
+
+    public MongoDBRef? Problem { get; set; }
+}

--- a/src/Tsa.Submissions.Coding.WebApi/Entities/TestSetInput.cs
+++ b/src/Tsa.Submissions.Coding.WebApi/Entities/TestSetInput.cs
@@ -6,5 +6,7 @@ public class TestSetInput
 
     public int? Index { get; set; }
 
-    public string? Value { get; set; }
+    public bool IsArray { get; set; }
+
+    public string? ValueAsJson { get; set; }
 }

--- a/src/Tsa.Submissions.Coding.WebApi/Entities/TestSetInput.cs
+++ b/src/Tsa.Submissions.Coding.WebApi/Entities/TestSetInput.cs
@@ -1,0 +1,10 @@
+﻿namespace Tsa.Submissions.Coding.WebApi.Entities;
+
+public class TestSetInput
+{
+    public string? DataType { get; set; }
+
+    public int? Index { get; set; }
+
+    public string? Value { get; set; }
+}

--- a/src/Tsa.Submissions.Coding.WebApi/Entities/TestSetInputDataTypes.cs
+++ b/src/Tsa.Submissions.Coding.WebApi/Entities/TestSetInputDataTypes.cs
@@ -1,0 +1,9 @@
+﻿namespace Tsa.Submissions.Coding.WebApi.Entities;
+
+public enum TestSetInputDataTypes
+{
+    Character,
+    Decimal,
+    Number,
+    String
+}

--- a/src/Tsa.Submissions.Coding.WebApi/Exceptions/IWebApiException.cs
+++ b/src/Tsa.Submissions.Coding.WebApi/Exceptions/IWebApiException.cs
@@ -1,0 +1,10 @@
+using System.Net;
+
+namespace PointOfSales.BackOffice.Services.WebApi.Exceptions;
+
+public interface IWebApiException
+{
+    HttpStatusCode HttpStatusCode { get; }
+
+    ApiErrorResponse ToApiErrorResponseModel();
+}

--- a/src/Tsa.Submissions.Coding.WebApi/Exceptions/IWebApiException.cs
+++ b/src/Tsa.Submissions.Coding.WebApi/Exceptions/IWebApiException.cs
@@ -1,6 +1,7 @@
 using System.Net;
+using Tsa.Submissions.Coding.WebApi.Models;
 
-namespace PointOfSales.BackOffice.Services.WebApi.Exceptions;
+namespace Tsa.Submissions.Coding.WebApi.Exceptions;
 
 public interface IWebApiException
 {

--- a/src/Tsa.Submissions.Coding.WebApi/Exceptions/RequiredEntityNotFoundException.cs
+++ b/src/Tsa.Submissions.Coding.WebApi/Exceptions/RequiredEntityNotFoundException.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Net;
+using PointOfSales.BackOffice.Services.WebApi.Exceptions;
+
+namespace Tsa.Submissions.Coding.WebApi.Exceptions;
+
+public class RequiredEntityNotFoundException : Exception, IWebApiException
+{
+    public string EntityName { get; }
+
+    public HttpStatusCode HttpStatusCode { get; }
+
+    public RequiredEntityNotFoundException(string entityName) : base($"Could not locate required resource for the `{entityName}` entity.")
+    {
+        EntityName = entityName;
+        HttpStatusCode = HttpStatusCode.NotFound;
+    }
+
+    public ApiErrorResponse ToApiErrorResponseModel()
+    {
+        return new ApiErrorResponse
+        {
+            ErrorCode = (int)ErrorCodes.RequiredAttributeNotFound,
+            Message = Message
+        };
+    }
+}

--- a/src/Tsa.Submissions.Coding.WebApi/Exceptions/RequiredEntityNotFoundException.cs
+++ b/src/Tsa.Submissions.Coding.WebApi/Exceptions/RequiredEntityNotFoundException.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Net;
-using PointOfSales.BackOffice.Services.WebApi.Exceptions;
+using Tsa.Submissions.Coding.WebApi.Models;
 
 namespace Tsa.Submissions.Coding.WebApi.Exceptions;
 

--- a/src/Tsa.Submissions.Coding.WebApi/Models/ApiErrorResponse.cs
+++ b/src/Tsa.Submissions.Coding.WebApi/Models/ApiErrorResponse.cs
@@ -1,3 +1,5 @@
+namespace Tsa.Submissions.Coding.WebApi.Models;
+
 public class ApiErrorResponse
 {
     public int ErrorCode { get; set; }

--- a/src/Tsa.Submissions.Coding.WebApi/Models/ApiErrorResponse.cs
+++ b/src/Tsa.Submissions.Coding.WebApi/Models/ApiErrorResponse.cs
@@ -1,0 +1,8 @@
+public class ApiErrorResponse
+{
+    public int ErrorCode { get; set; }
+
+    public string? Message { get; set; }
+
+    public static ApiErrorResponse Unauthorized => new() { ErrorCode = (int)ErrorCodes.Unauthorized, Message = "Client is unauthorized" };
+}

--- a/src/Tsa.Submissions.Coding.WebApi/Models/ErrorCodes.cs
+++ b/src/Tsa.Submissions.Coding.WebApi/Models/ErrorCodes.cs
@@ -1,0 +1,5 @@
+public enum ErrorCodes
+{
+    Unauthorized = 1000,
+    RequiredAttributeNotFound = 2000
+}

--- a/src/Tsa.Submissions.Coding.WebApi/Models/ErrorCodes.cs
+++ b/src/Tsa.Submissions.Coding.WebApi/Models/ErrorCodes.cs
@@ -1,3 +1,5 @@
+namespace Tsa.Submissions.Coding.WebApi.Models;
+
 public enum ErrorCodes
 {
     Unauthorized = 1000,

--- a/src/Tsa.Submissions.Coding.WebApi/Models/ModelExtensions.cs
+++ b/src/Tsa.Submissions.Coding.WebApi/Models/ModelExtensions.cs
@@ -67,7 +67,8 @@ public static class ModelExtensions
         {
             DataType = testSetInputModel.DataType,
             Index = testSetInputModel.Index,
-            Value = testSetInputModel.Value
+            IsArray = testSetInputModel.IsArray,
+            ValueAsJson = testSetInputModel.ValueAsJson
         };
     }
 }

--- a/src/Tsa.Submissions.Coding.WebApi/Models/ModelExtensions.cs
+++ b/src/Tsa.Submissions.Coding.WebApi/Models/ModelExtensions.cs
@@ -1,11 +1,18 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using MongoDB.Driver;
 using Tsa.Submissions.Coding.WebApi.Entities;
+using Tsa.Submissions.Coding.WebApi.Services;
 
 namespace Tsa.Submissions.Coding.WebApi.Models;
 
 public static class ModelExtensions
 {
+    public static IList<TestSetInput>? ToEntities(this IList<TestSetInputModel>? testSetInputModels)
+    {
+        return testSetInputModels?.Select(testSetInputModel => testSetInputModel.ToEntity()).ToList();
+    }
+
     public static List<Participant> ToEntities(this IList<ParticipantModel> participants)
     {
         return participants.Select(participant => participant.ToEntity()).ToList();
@@ -39,6 +46,28 @@ public static class ModelExtensions
             Participants = teamModel.Participants.ToEntities(),
             SchoolNumber = teamModel.SchoolNumber,
             TeamNumber = teamModel.TeamNumber
+        };
+    }
+
+    public static TestSet ToEntity(this TestSetModel testSetModel)
+    {
+        return new TestSet
+        {
+            Id = testSetModel.Id,
+            Inputs = testSetModel.Inputs.ToEntities(),
+            IsPublic = testSetModel.IsPublic,
+            Name = testSetModel.Name,
+            Problem = new MongoDBRef(ProblemsService.MongoDbCollectionName, testSetModel.ProblemId)
+        };
+    }
+
+    public static TestSetInput ToEntity(this TestSetInputModel testSetInputModel)
+    {
+        return new TestSetInput
+        {
+            DataType = testSetInputModel.DataType,
+            Index = testSetInputModel.Index,
+            Value = testSetInputModel.Value
         };
     }
 }

--- a/src/Tsa.Submissions.Coding.WebApi/Models/ProblemModel.cs
+++ b/src/Tsa.Submissions.Coding.WebApi/Models/ProblemModel.cs
@@ -1,4 +1,6 @@
-﻿namespace Tsa.Submissions.Coding.WebApi.Models;
+﻿using System.Collections.Generic;
+
+namespace Tsa.Submissions.Coding.WebApi.Models;
 
 public class ProblemModel
 {
@@ -7,6 +9,8 @@ public class ProblemModel
     public string? Id { get; set; }
 
     public bool IsActive { get; set; }
+
+    public IList<TestSetModel>? TestSets { get; set; }
 
     public string? Title { get; set; }
 }

--- a/src/Tsa.Submissions.Coding.WebApi/Models/ServicesStatusModel.cs
+++ b/src/Tsa.Submissions.Coding.WebApi/Models/ServicesStatusModel.cs
@@ -2,8 +2,11 @@
 
 public class ServicesStatusModel
 {
-    public bool IsHealthy => ProblemsServiceIsAlive && TeamsServiceIsAlive;
+    public bool IsHealthy => ProblemsServiceIsAlive && TeamsServiceIsAlive && TestSetsServiceIsAlive;
+
     public bool ProblemsServiceIsAlive { get; set; }
 
     public bool TeamsServiceIsAlive { get; set; }
+
+    public bool TestSetsServiceIsAlive { get; set; }
 }

--- a/src/Tsa.Submissions.Coding.WebApi/Models/TestSetInputModel.cs
+++ b/src/Tsa.Submissions.Coding.WebApi/Models/TestSetInputModel.cs
@@ -1,0 +1,10 @@
+﻿namespace Tsa.Submissions.Coding.WebApi.Models;
+
+public class TestSetInputModel
+{
+    public string? DataType { get; set; }
+
+    public int? Index { get; set; }
+
+    public string? Value { get; set; }
+}

--- a/src/Tsa.Submissions.Coding.WebApi/Models/TestSetInputModel.cs
+++ b/src/Tsa.Submissions.Coding.WebApi/Models/TestSetInputModel.cs
@@ -6,5 +6,7 @@ public class TestSetInputModel
 
     public int? Index { get; set; }
 
-    public string? Value { get; set; }
+    public bool IsArray { get; set; }
+
+    public string? ValueAsJson { get; set; }
 }

--- a/src/Tsa.Submissions.Coding.WebApi/Models/TestSetModel.cs
+++ b/src/Tsa.Submissions.Coding.WebApi/Models/TestSetModel.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections.Generic;
+
+namespace Tsa.Submissions.Coding.WebApi.Models;
+
+public class TestSetModel
+{
+    public string? Id { get; set; }
+
+    public IList<TestSetInputModel>? Inputs { get; set; }
+
+    public bool IsPublic { get; set; }
+
+    public string? Name { get; set; }
+
+    public string? ProblemId { get; set; }
+}

--- a/src/Tsa.Submissions.Coding.WebApi/Models/ValueAsCharacterArrayModel.cs
+++ b/src/Tsa.Submissions.Coding.WebApi/Models/ValueAsCharacterArrayModel.cs
@@ -1,0 +1,6 @@
+namespace Tsa.Submissions.Coding.WebApi.Models;
+
+public class ValueAsCharacterArrayModel
+{
+    public char[]? Value { get; set; }
+}

--- a/src/Tsa.Submissions.Coding.WebApi/Models/ValueAsCharacterModel.cs
+++ b/src/Tsa.Submissions.Coding.WebApi/Models/ValueAsCharacterModel.cs
@@ -1,0 +1,6 @@
+﻿namespace Tsa.Submissions.Coding.WebApi.Models;
+
+public class ValueAsCharacterModel
+{
+    public char? Value { get; set; }
+}

--- a/src/Tsa.Submissions.Coding.WebApi/Models/ValueAsDecimalArrayModel.cs
+++ b/src/Tsa.Submissions.Coding.WebApi/Models/ValueAsDecimalArrayModel.cs
@@ -1,0 +1,6 @@
+namespace Tsa.Submissions.Coding.WebApi.Models;
+
+public class ValueAsDecimalArrayModel
+{
+    public decimal[]? Value { get; set; }
+}

--- a/src/Tsa.Submissions.Coding.WebApi/Models/ValueAsDecimalModel.cs
+++ b/src/Tsa.Submissions.Coding.WebApi/Models/ValueAsDecimalModel.cs
@@ -1,0 +1,6 @@
+namespace Tsa.Submissions.Coding.WebApi.Models;
+
+public class ValueAsDecimalModel
+{
+    public decimal? Value { get; set; }
+}

--- a/src/Tsa.Submissions.Coding.WebApi/Models/ValueAsNumberArrayModel.cs
+++ b/src/Tsa.Submissions.Coding.WebApi/Models/ValueAsNumberArrayModel.cs
@@ -1,0 +1,6 @@
+namespace Tsa.Submissions.Coding.WebApi.Models;
+
+public class ValueAsNumberArrayModel
+{
+    public int[]? Value { get; set; }
+}

--- a/src/Tsa.Submissions.Coding.WebApi/Models/ValueAsNumberModel.cs
+++ b/src/Tsa.Submissions.Coding.WebApi/Models/ValueAsNumberModel.cs
@@ -1,0 +1,6 @@
+namespace Tsa.Submissions.Coding.WebApi.Models;
+
+public class ValueAsNumberModel
+{
+    public int? Value { get; set; }
+}

--- a/src/Tsa.Submissions.Coding.WebApi/Models/ValueAsStringArrayModel.cs
+++ b/src/Tsa.Submissions.Coding.WebApi/Models/ValueAsStringArrayModel.cs
@@ -1,0 +1,6 @@
+namespace Tsa.Submissions.Coding.WebApi.Models;
+
+public class ValueAsStringArrayModel
+{
+    public string[]? Value { get; set; }
+}

--- a/src/Tsa.Submissions.Coding.WebApi/Models/ValueAsStringModel.cs
+++ b/src/Tsa.Submissions.Coding.WebApi/Models/ValueAsStringModel.cs
@@ -1,0 +1,6 @@
+namespace Tsa.Submissions.Coding.WebApi.Models;
+
+public class ValueAsStringModel
+{
+    public string? Value { get; set; }
+}

--- a/src/Tsa.Submissions.Coding.WebApi/Services/ITestSetsService.cs
+++ b/src/Tsa.Submissions.Coding.WebApi/Services/ITestSetsService.cs
@@ -1,5 +1,11 @@
-﻿using Tsa.Submissions.Coding.WebApi.Entities;
+﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Tsa.Submissions.Coding.WebApi.Entities;
 
 namespace Tsa.Submissions.Coding.WebApi.Services;
 
-public interface ITestSetsService : IMongoEntityService<TestSet>, IPingableService { }
+public interface ITestSetsService : IMongoEntityService<TestSet>, IPingableService
+{
+    Task<List<TestSet>> GetAsync(Problem problem, CancellationToken cancellationToken = default);
+}

--- a/src/Tsa.Submissions.Coding.WebApi/Services/ITestSetsService.cs
+++ b/src/Tsa.Submissions.Coding.WebApi/Services/ITestSetsService.cs
@@ -2,4 +2,4 @@
 
 namespace Tsa.Submissions.Coding.WebApi.Services;
 
-public interface ITestSetsService: IMongoEntityService<TestSet>, IPingableService { }
+public interface ITestSetsService : IMongoEntityService<TestSet>, IPingableService { }

--- a/src/Tsa.Submissions.Coding.WebApi/Services/ITestSetsService.cs
+++ b/src/Tsa.Submissions.Coding.WebApi/Services/ITestSetsService.cs
@@ -1,0 +1,5 @@
+﻿using Tsa.Submissions.Coding.WebApi.Entities;
+
+namespace Tsa.Submissions.Coding.WebApi.Services;
+
+public interface ITestSetsService: IMongoEntityService<TestSet>, IPingableService { }

--- a/src/Tsa.Submissions.Coding.WebApi/Services/TestSetsService.cs
+++ b/src/Tsa.Submissions.Coding.WebApi/Services/TestSetsService.cs
@@ -24,7 +24,7 @@ public class TestSetsService : MongoDbService<TestSet>, ITestSetsService
 
     public async Task<List<TestSet>> GetAsync(Problem problem, CancellationToken cancellationToken = default)
     {
-        var filterDefinition = Builders<TestSet>.Filter.Eq(_ => _.Problem!.Id.AsString, problem.Id);
+        var filterDefinition = Builders<TestSet>.Filter.Eq(_ => _.Problem!.Id, problem.Id);
 
         var cursor = await EntityCollection.FindAsync(filterDefinition, null, cancellationToken);
 

--- a/src/Tsa.Submissions.Coding.WebApi/Services/TestSetsService.cs
+++ b/src/Tsa.Submissions.Coding.WebApi/Services/TestSetsService.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.Extensions.Options;
+﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
 using MongoDB.Driver;
 using Tsa.Submissions.Coding.WebApi.Configuration;
 using Tsa.Submissions.Coding.WebApi.Entities;
@@ -18,4 +21,15 @@ public class TestSetsService : MongoDbService<TestSet>, ITestSetsService
         options.Value.DatabaseName,
         MongoDbCollectionName)
     { }
+
+    public async Task<List<TestSet>> GetAsync(Problem problem, CancellationToken cancellationToken = default)
+    {
+        var filterDefinition = Builders<TestSet>.Filter.Eq(_ => _.Problem!.Id.AsString, problem.Id);
+
+        var cursor = await EntityCollection.FindAsync(filterDefinition, null, cancellationToken);
+
+        var result = await cursor.ToListAsync(cancellationToken);
+
+        return result;
+    }
 }

--- a/src/Tsa.Submissions.Coding.WebApi/Services/TestSetsService.cs
+++ b/src/Tsa.Submissions.Coding.WebApi/Services/TestSetsService.cs
@@ -16,5 +16,6 @@ public class TestSetsService : MongoDbService<TestSet>, ITestSetsService
     public TestSetsService(IMongoClient mongoClient, IOptions<SubmissionsDatabase> options) : base(
         mongoClient,
         options.Value.DatabaseName,
-        MongoDbCollectionName) { }
+        MongoDbCollectionName)
+    { }
 }

--- a/src/Tsa.Submissions.Coding.WebApi/Services/TestSetsService.cs
+++ b/src/Tsa.Submissions.Coding.WebApi/Services/TestSetsService.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.Extensions.Options;
+using MongoDB.Driver;
+using Tsa.Submissions.Coding.WebApi.Configuration;
+using Tsa.Submissions.Coding.WebApi.Entities;
+
+namespace Tsa.Submissions.Coding.WebApi.Services;
+
+public class TestSetsService : MongoDbService<TestSet>, ITestSetsService
+{
+    public const string MongoDbCollectionName = "test-sets";
+
+    public string CollectionName => MongoDbCollectionName;
+
+    public string ServiceName => "TestSets";
+
+    public TestSetsService(IMongoClient mongoClient, IOptions<SubmissionsDatabase> options) : base(
+        mongoClient,
+        options.Value.DatabaseName,
+        MongoDbCollectionName) { }
+}

--- a/src/Tsa.Submissions.Coding.WebApi/Startup.cs
+++ b/src/Tsa.Submissions.Coding.WebApi/Startup.cs
@@ -102,10 +102,12 @@ public class Startup
         // Add MongoDB Services
         services.AddSingleton<IProblemsService, ProblemsService>();
         services.AddSingleton<ITeamsService, TeamsService>();
+        services.AddSingleton<ITestSetsService, TestSetsService>();
 
         // Add Pingable Services - Should match MongoDB Services
         services.AddSingleton<IPingableService, ProblemsService>();
         services.AddSingleton<IPingableService, TeamsService>();
+        services.AddSingleton<IPingableService, TestSetsService>();
 
         // Add Validators
         services.AddScoped<IValidator<ProblemModel>, ProblemModelValidator>();

--- a/src/Tsa.Submissions.Coding.WebApi/Startup.cs
+++ b/src/Tsa.Submissions.Coding.WebApi/Startup.cs
@@ -110,6 +110,7 @@ public class Startup
         // Add Validators
         services.AddScoped<IValidator<ProblemModel>, ProblemModelValidator>();
         services.AddScoped<IValidator<TeamModel>, TeamModelValidator>();
+        services.AddScoped<IValidator<TestSetModel>, TestSetModelValidator>();
 
         // Setup authentication and authorization
         var requireAuthenticatedUserPolicy = new AuthorizationPolicyBuilder()

--- a/src/Tsa.Submissions.Coding.WebApi/Validators/TestSetInputsPropertyValidator.cs
+++ b/src/Tsa.Submissions.Coding.WebApi/Validators/TestSetInputsPropertyValidator.cs
@@ -99,7 +99,7 @@ public class TestSetInputsPropertyValidator : PropertyValidator<TestSetModel, IL
                 ? IsValidJsonType<ValueAsStringArrayModel>(testSetInputModel.ValueAsJson)
                 : IsValidJsonType<ValueAsStringModel>(testSetInputModel.ValueAsJson),
 
-            _ => throw new NotImplementedException($"Parsing for the `{testSetInputDataType}` is not supported.")
+            _ => throw new NotImplementedException($"Parsing for the `{testSetInputDataType}` data type is not supported.")
         };
     }
 }

--- a/src/Tsa.Submissions.Coding.WebApi/Validators/TestSetInputsPropertyValidator.cs
+++ b/src/Tsa.Submissions.Coding.WebApi/Validators/TestSetInputsPropertyValidator.cs
@@ -78,7 +78,7 @@ public class TestSetInputsPropertyValidator : PropertyValidator<TestSetModel, IL
 
         if (string.IsNullOrWhiteSpace(testSetInputModel.ValueAsJson))
         {
-            throw new ArgumentException("The value cannot be null.", nameof(TestSetInputModel.ValueAsJson));
+            throw new ArgumentException("The JSON value cannot be null.");
         }
 
         return testSetInputDataType switch

--- a/src/Tsa.Submissions.Coding.WebApi/Validators/TestSetInputsPropertyValidator.cs
+++ b/src/Tsa.Submissions.Coding.WebApi/Validators/TestSetInputsPropertyValidator.cs
@@ -24,25 +24,25 @@ public class TestSetInputsPropertyValidator : PropertyValidator<TestSetModel, IL
         {
             if (string.IsNullOrWhiteSpace(testSetInputModel.DataType) || !IsValidDataType(testSetInputModel.DataType))
             {
-                context.AddFailure(nameof(TestSetInputModel.DataType), "You must specify a valid data type for the input");
+                context.AddFailure("You must specify a valid data type for the input");
                 return false;
             }
 
             if (testSetInputModel.Index == null)
             {
-                context.AddFailure(nameof(TestSetInputModel.Index), "There must be a value for the index");
+                context.AddFailure("There must be a value for the index");
                 return false;
             }
 
             if (string.IsNullOrWhiteSpace(testSetInputModel.ValueAsJson))
             {
-                context.AddFailure(nameof(TestSetInputModel.ValueAsJson), "You must specify a value for the input");
+                context.AddFailure("You must specify a value for the input");
                 return false;
             }
 
             if (!ValueParsesToDataType(testSetInputModel))
             {
-                context.AddFailure(nameof(TestSetInputModel.ValueAsJson), "The value must parse to the specified data type.");
+                context.AddFailure("Unable to deserialize the value to the specified data type");
                 return false;
             }
         }
@@ -52,7 +52,7 @@ public class TestSetInputsPropertyValidator : PropertyValidator<TestSetModel, IL
 
     private static bool IsValidDataType(string dataType)
     {
-        return Enum.TryParse<TestSetInputDataTypes>(dataType, out _);
+        return Enum.TryParse<TestSetInputDataTypes>(dataType, true, out _);
     }
 
     private static bool IsValidJsonType<T>(string jsonValue)
@@ -71,14 +71,14 @@ public class TestSetInputsPropertyValidator : PropertyValidator<TestSetModel, IL
 
     private static bool ValueParsesToDataType(TestSetInputModel testSetInputModel)
     {
-        if (!Enum.TryParse<TestSetInputDataTypes>(testSetInputModel.DataType, out var testSetInputDataType))
+        if (!Enum.TryParse<TestSetInputDataTypes>(testSetInputModel.DataType, true, out var testSetInputDataType))
         {
-            throw new ArgumentException("Unable to determine the data type of the value.");
+            throw new ArgumentException("Unable to determine the data type of the value");
         }
 
         if (string.IsNullOrWhiteSpace(testSetInputModel.ValueAsJson))
         {
-            throw new ArgumentException("The JSON value cannot be null.");
+            throw new ArgumentException("The JSON value cannot be null");
         }
 
         return testSetInputDataType switch
@@ -99,7 +99,7 @@ public class TestSetInputsPropertyValidator : PropertyValidator<TestSetModel, IL
                 ? IsValidJsonType<ValueAsStringArrayModel>(testSetInputModel.ValueAsJson)
                 : IsValidJsonType<ValueAsStringModel>(testSetInputModel.ValueAsJson),
 
-            _ => throw new NotImplementedException($"Parsing for the `{testSetInputDataType}` data type is not supported.")
+            _ => throw new NotImplementedException($"Parsing for the `{testSetInputDataType}` data type is not supported")
         };
     }
 }

--- a/src/Tsa.Submissions.Coding.WebApi/Validators/TestSetInputsPropertyValidator.cs
+++ b/src/Tsa.Submissions.Coding.WebApi/Validators/TestSetInputsPropertyValidator.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using FluentValidation;
 using FluentValidation.Validators;
 using Newtonsoft.Json;
@@ -20,6 +21,8 @@ public class TestSetInputsPropertyValidator : PropertyValidator<TestSetModel, IL
             return false;
         }
 
+        var indexes = new List<int>();
+
         foreach (var testSetInputModel in value)
         {
             if (string.IsNullOrWhiteSpace(testSetInputModel.DataType) || !IsValidDataType(testSetInputModel.DataType))
@@ -34,6 +37,14 @@ public class TestSetInputsPropertyValidator : PropertyValidator<TestSetModel, IL
                 return false;
             }
 
+            if (indexes.Contains(testSetInputModel.Index.Value))
+            {
+                context.AddFailure(nameof(TestSetInputModel.Index), "The value for the input index must be unique");
+                return false;
+            }
+
+            indexes.Add(testSetInputModel.Index.Value);
+
             if (string.IsNullOrWhiteSpace(testSetInputModel.ValueAsJson))
             {
                 context.AddFailure(nameof(TestSetInputModel.ValueAsJson), "You must specify a value for the input");
@@ -45,6 +56,18 @@ public class TestSetInputsPropertyValidator : PropertyValidator<TestSetModel, IL
                 context.AddFailure(nameof(TestSetInputModel.ValueAsJson), "The value must parse to the specified data type.");
                 return false;
             }
+        }
+
+        var expectedValue = 0;
+        foreach (var index in indexes.Order())
+        {
+            if (index != expectedValue)
+            {
+                context.AddFailure(nameof(TestSetInputModel.Index), "Indexes need to start at 0 and must be continuous.");
+                return false;
+            }
+
+            expectedValue++;
         }
 
         return true;

--- a/src/Tsa.Submissions.Coding.WebApi/Validators/TestSetInputsPropertyValidator.cs
+++ b/src/Tsa.Submissions.Coding.WebApi/Validators/TestSetInputsPropertyValidator.cs
@@ -39,7 +39,7 @@ public class TestSetInputsPropertyValidator : PropertyValidator<TestSetModel, IL
 
             if (indexes.Contains(testSetInputModel.Index.Value))
             {
-                context.AddFailure(nameof(TestSetInputModel.Index), "The value for the input index must be unique");
+                context.AddFailure("The value for the input index must be unique");
                 return false;
             }
 
@@ -53,7 +53,7 @@ public class TestSetInputsPropertyValidator : PropertyValidator<TestSetModel, IL
 
             if (!ValueParsesToDataType(testSetInputModel))
             {
-                context.AddFailure("Unable to deserialize the value to the specified data type");
+                context.AddFailure($"Unable to deserialize the value `{testSetInputModel.ValueAsJson}` to the specified data type `{testSetInputModel.DataType}`");
                 return false;
             }
         }
@@ -63,7 +63,7 @@ public class TestSetInputsPropertyValidator : PropertyValidator<TestSetModel, IL
         {
             if (index != expectedValue)
             {
-                context.AddFailure(nameof(TestSetInputModel.Index), "Indexes need to start at 0 and must be continuous.");
+                context.AddFailure("Indexes need to start at 0 and must be continuous.");
                 return false;
             }
 

--- a/src/Tsa.Submissions.Coding.WebApi/Validators/TestSetInputsPropertyValidator.cs
+++ b/src/Tsa.Submissions.Coding.WebApi/Validators/TestSetInputsPropertyValidator.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.Collections.Generic;
+using FluentValidation;
+using FluentValidation.Validators;
+using Newtonsoft.Json;
+using Tsa.Submissions.Coding.WebApi.Entities;
+using Tsa.Submissions.Coding.WebApi.Models;
+
+namespace Tsa.Submissions.Coding.WebApi.Validators;
+
+public class TestSetInputsPropertyValidator : PropertyValidator<TestSetModel, IList<TestSetInputModel>?>
+{
+    public override string Name => "TestSetInputsPropertyValidator";
+
+    public override bool IsValid(ValidationContext<TestSetModel> context, IList<TestSetInputModel>? value)
+    {
+        if (value == null || value.Count == 0)
+        {
+            context.AddFailure("At least one input for the test is required");
+            return false;
+        }
+
+        foreach (var testSetInputModel in value)
+        {
+            if (string.IsNullOrWhiteSpace(testSetInputModel.DataType) || !IsValidDataType(testSetInputModel.DataType))
+            {
+                context.AddFailure(nameof(TestSetInputModel.DataType), "You must specify a valid data type for the input");
+                return false;
+            }
+
+            if (testSetInputModel.Index == null)
+            {
+                context.AddFailure(nameof(TestSetInputModel.Index), "There must be a value for the index");
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(testSetInputModel.ValueAsJson))
+            {
+                context.AddFailure(nameof(TestSetInputModel.ValueAsJson), "You must specify a value for the input");
+                return false;
+            }
+
+            if (!ValueParsesToDataType(testSetInputModel))
+            {
+                context.AddFailure(nameof(TestSetInputModel.ValueAsJson), "The value must parse to the specified data type.");
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool IsValidDataType(string dataType)
+    {
+        return Enum.TryParse<TestSetInputDataTypes>(dataType, out _);
+    }
+
+    private static bool IsValidJsonType<T>(string jsonValue)
+    {
+        try
+        {
+            JsonConvert.DeserializeObject<T>(jsonValue);
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool ValueParsesToDataType(TestSetInputModel testSetInputModel)
+    {
+        if (!Enum.TryParse<TestSetInputDataTypes>(testSetInputModel.DataType, out var testSetInputDataType))
+        {
+            throw new ArgumentException("Unable to determine the data type of the value.");
+        }
+
+        if (string.IsNullOrWhiteSpace(testSetInputModel.ValueAsJson))
+        {
+            throw new ArgumentException("The value cannot be null.", nameof(TestSetInputModel.ValueAsJson));
+        }
+
+        return testSetInputDataType switch
+        {
+            TestSetInputDataTypes.Character => testSetInputModel.IsArray
+                ? IsValidJsonType<ValueAsCharacterArrayModel>(testSetInputModel.ValueAsJson)
+                : IsValidJsonType<ValueAsCharacterModel>(testSetInputModel.ValueAsJson),
+
+            TestSetInputDataTypes.Decimal => testSetInputModel.IsArray
+                ? IsValidJsonType<ValueAsDecimalArrayModel>(testSetInputModel.ValueAsJson)
+                : IsValidJsonType<ValueAsDecimalModel>(testSetInputModel.ValueAsJson),
+
+            TestSetInputDataTypes.Number => testSetInputModel.IsArray
+                ? IsValidJsonType<ValueAsNumberArrayModel>(testSetInputModel.ValueAsJson)
+                : IsValidJsonType<ValueAsNumberModel>(testSetInputModel.ValueAsJson),
+
+            TestSetInputDataTypes.String => testSetInputModel.IsArray
+                ? IsValidJsonType<ValueAsStringArrayModel>(testSetInputModel.ValueAsJson)
+                : IsValidJsonType<ValueAsStringModel>(testSetInputModel.ValueAsJson),
+
+            _ => throw new NotImplementedException($"Parsing for the `{testSetInputDataType}` is not supported.")
+        };
+    }
+}

--- a/src/Tsa.Submissions.Coding.WebApi/Validators/TestSetModelValidator.cs
+++ b/src/Tsa.Submissions.Coding.WebApi/Validators/TestSetModelValidator.cs
@@ -1,0 +1,22 @@
+﻿using FluentValidation;
+using Tsa.Submissions.Coding.WebApi.Models;
+
+namespace Tsa.Submissions.Coding.WebApi.Validators;
+
+public class TestSetModelValidator : AbstractValidator<TestSetModel>
+{
+    public TestSetModelValidator()
+    {
+        RuleFor(testSetModel => testSetModel.Name)
+            .NotEmpty()
+            .WithMessage("A name is required for the test set");
+
+        RuleFor(testSetModel => testSetModel.Inputs)
+            .SetValidator(new TestSetInputsPropertyValidator())
+            .WithMessage("The input(s) are not valid");
+
+        RuleFor(testSetModel => testSetModel.ProblemId)
+            .NotEmpty()
+            .WithMessage("A problem ID is required for the test set");
+    }
+}


### PR DESCRIPTION
Added the ability to create, read, update, and delete test sets. Updated the `ProblemsController` to allow for the test sets associated with the problem to be expanded. I also added a series of equality comparers to help simplify the unit tests. This will help with maintainability over time.

This closes #14 